### PR TITLE
MJM-179: add complementary nav background on non-home pages

### DIFF
--- a/style.css
+++ b/style.css
@@ -30,6 +30,7 @@ Text Domain: rolling-reno
   --max-width: 1200px;
   --content-width: 740px;
   --spacing-unit: 8px;
+  --site-header-offset: 72px;
 }
 
 * {
@@ -43,6 +44,10 @@ body {
   color: var(--color-charcoal);
   background: var(--color-warm-white);
   line-height: 1.75;
+}
+
+body:not(.home) {
+  padding-top: var(--site-header-offset);
 }
 
 .site-header {
@@ -62,4 +67,10 @@ body.home .site-header {
   backdrop-filter: none;
   -webkit-backdrop-filter: none;
   border-bottom-color: transparent;
+}
+
+@media (max-width: 782px) {
+  :root {
+    --site-header-offset: 60px;
+  }
 }

--- a/style.css
+++ b/style.css
@@ -44,3 +44,22 @@ body {
   background: var(--color-warm-white);
   line-height: 1.75;
 }
+
+.site-header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 1000;
+  background: rgba(61, 90, 71, 0.96);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  border-bottom: 1px solid rgba(232, 223, 208, 0.35);
+}
+
+body.home .site-header {
+  background: transparent;
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+  border-bottom-color: transparent;
+}


### PR DESCRIPTION
## Summary
- add a complementary solid nav background for non-home pages
- preserve the transparent homepage nav treatment
- keep the change isolated to theme stylesheet overrides

## Notes
- production Flywheel theme was updated and cache flushed because live theme state is ahead of the checked-in repo
- reviewer still needs to be tagged per workflow