### PR TITLE
feat(cd): GitHub Actions auto-deploy to Flywheel (MJM-195)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,53 @@
+name: Deploy to Flywheel Production
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    name: SSH Deploy → Flywheel
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up SSH key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.FLYWHEEL_SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H "${{ secrets.FLYWHEEL_SSH_HOST }}" >> ~/.ssh/known_hosts 2>/dev/null
+
+      - name: Deploy theme files via rsync
+        run: |
+          rsync -avz --delete \
+            --exclude='.git' \
+            --exclude='.github' \
+            --exclude='node_modules' \
+            --exclude='*.md' \
+            -e "ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=no" \
+            ./ \
+            "${{ secrets.FLYWHEEL_SSH_USER }}@${{ secrets.FLYWHEEL_SSH_HOST }}:/www/wp-content/themes/rolling-reno-v2/"
+
+      - name: Set file permissions
+        run: |
+          ssh -i ~/.ssh/deploy_key \
+            -o StrictHostKeyChecking=no \
+            "${{ secrets.FLYWHEEL_SSH_USER }}@${{ secrets.FLYWHEEL_SSH_HOST }}" \
+            "find /www/wp-content/themes/rolling-reno-v2 -type d -exec chmod 755 {} \; && find /www/wp-content/themes/rolling-reno-v2 -type f -exec chmod 644 {} \;"
+
+      - name: Flush Flywheel cache
+        run: |
+          ssh -i ~/.ssh/deploy_key \
+            -o StrictHostKeyChecking=no \
+            "${{ secrets.FLYWHEEL_SSH_USER }}@${{ secrets.FLYWHEEL_SSH_HOST }}" \
+            "php /www/fw-flush-cache.php"
+
+      - name: Deployment complete
+        run: |
+          echo "✅ Rolling Reno theme deployed to Flywheel production."
+          echo "   Host: ${{ secrets.FLYWHEEL_SSH_HOST }}"
+          echo "   Path: /www/wp-content/themes/rolling-reno-v2/"


### PR DESCRIPTION
## MJM-195 — Replace Manual Deploy with GitHub Actions CD

### What this does
- Adds `.github/workflows/deploy.yml` triggered on every push to `main` (PR merge)
- SSH rsync to Flywheel production: `/www/wp-content/themes/rolling-reno-v2/`
- Sets correct file permissions (dirs: 755, files: 644) post-deploy
- Flushes Flywheel cache via `php /www/fw-flush-cache.php`
- Uses GitHub Secrets: `FLYWHEEL_SSH_KEY`, `FLYWHEEL_SSH_HOST`, `FLYWHEEL_SSH_USER` (all set ✅)

### Secrets added to repo
- `FLYWHEEL_SSH_KEY` — ed25519 private key from VM
- `FLYWHEEL_SSH_HOST` — ssh.getflywheel.com
- `FLYWHEEL_SSH_USER` — cianbyrne1010+rollling-reno

### Testing
Merge this PR — the workflow will fire on the merge commit and deploy the current theme to Flywheel production.

Closes MJM-195