### PR TITLE
fix: enqueue design-system.css and main.css [CRITICAL]

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -115,11 +115,27 @@ function rr_scripts() {
         null
     );
 
-    // Load the existing theme stylesheet only, this branch doesn't include the v2 asset bundle.
+    // Design system (typography, colors, spacing)
+    wp_enqueue_style(
+        'rr-design-system',
+        RR_THEME_URI . '/assets/css/design-system.css',
+        array( 'rr-google-fonts' ),
+        RR_VERSION
+    );
+
+    // Main stylesheet (layout, components, responsive)
+    wp_enqueue_style(
+        'rr-main',
+        RR_THEME_URI . '/assets/css/main.css',
+        array( 'rr-design-system' ),
+        RR_VERSION
+    );
+
+    // Theme stylesheet (WordPress requirement + overrides)
     wp_enqueue_style(
         'rr-theme',
         get_stylesheet_uri(),
-        array( 'rr-google-fonts' ),
+        array( 'rr-main' ),
         RR_VERSION
     );
 


### PR DESCRIPTION
## 🔴 Critical Fix

**The site is visually broken because CSS files are not loading.**

### Problem
- `design-system.css` (1184 lines) — **NOT LOADED**
- `main.css` (1752 lines) — **NOT LOADED**  
- `style.css` (90 lines) — was the only CSS being served

The comment in functions.php literally said: *"this branch doesn't include the v2 asset bundle"* — but the files ARE there, just not enqueued.

### Fix
Enqueue all three CSS files in dependency order:
1. `rr-design-system` → typography, colors, spacing
2. `rr-main` → layout, components, responsive  
3. `rr-theme` → WordPress header + overrides

### Verified
- [x] CSS files exist on server
- [x] Files contain expected styling (2900+ lines total)