### PR TITLE
fix: restore nav visibility CSS (MJM-179, MJM-191)

### DIFF
--- a/style.css
+++ b/style.css
@@ -88,3 +88,64 @@ h4[id] {
     --admin-bar-height: 46px;
   }
 }
+
+/* MJM-179: solid complementary nav background on non-home pages */
+body:not(.home) .site-nav {
+  background: rgba(61, 90, 71, 0.96);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  box-shadow: 0 1px 0 var(--color-border);
+}
+
+body:not(.home) .site-nav__logo-text,
+body:not(.home) .site-nav__link,
+body:not(.home) .site-nav__search-btn {
+  color: var(--color-text-inverse);
+}
+
+body:not(.home) .site-nav__hamburger span {
+  background: var(--color-text-inverse);
+}
+
+body:not(.home) .site-nav__link:hover,
+body:not(.home) .site-nav__link[aria-current="page"] {
+  color: var(--color-sand);
+  border-bottom-color: var(--color-sand);
+}
+
+/* MJM-191: home nav — gradient overlay for readability over hero image */
+body.home .site-nav:not(.site-nav--scrolled) {
+  background: linear-gradient(180deg, rgba(0, 0, 0, 0.55) 0%, transparent 100%);
+  box-shadow: none;
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+}
+
+/* MJM-191: ensure white text on home nav (unscrolled) */
+body.home .site-nav:not(.site-nav--scrolled) .site-nav__logo-text,
+body.home .site-nav:not(.site-nav--scrolled) .site-nav__link,
+body.home .site-nav:not(.site-nav--scrolled) .site-nav__search-btn {
+  color: var(--color-text-inverse);
+}
+
+body.home .site-nav:not(.site-nav--scrolled) .site-nav__hamburger span {
+  background: var(--color-text-inverse);
+}
+
+/* MJM-191: scrolled home nav — solid light background, dark text */
+body.home .site-nav.site-nav--scrolled {
+  background: rgba(250, 250, 248, 0.97);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  box-shadow: 0 1px 0 var(--color-border);
+}
+
+body.home .site-nav.site-nav--scrolled .site-nav__logo-text,
+body.home .site-nav.site-nav--scrolled .site-nav__link,
+body.home .site-nav.site-nav--scrolled .site-nav__search-btn {
+  color: var(--color-text-primary);
+}
+
+body.home .site-nav.site-nav--scrolled .site-nav__hamburger span {
+  background: var(--color-text-primary);
+}


### PR DESCRIPTION
Nav text was invisible on non-home pages and on scroll because the MJM-179 and MJM-191 fixes were not in the repo style.css.

## What was broken
- **Non-home pages:** Nav links were white text on white/light background (invisible)
- **Homepage scroll:** No transition to solid nav when scrolling

## Fixes restored
- **MJM-179:** Forest green nav background on interior pages
- **MJM-191:** Dark gradient on home nav for readability over hero
- **MJM-191:** Light nav background when scrolled on homepage

## Root cause
These fixes were on feature branches that got lost when templates were copied from v1 theme.

## Already applied to production
CSS has been patched directly on production and cache flushed.