### PR TITLE
fix(nav): persistent sticky nav scroll behaviour (MJM-186)

### DIFF
--- a/style.css
+++ b/style.css
@@ -44,8 +44,10 @@ body {
   text-decoration: underline;
 }
 
-body:not(.home) {
-  padding-top: var(--site-header-offset);
+/* MJM-186: pull home-page hero behind the fixed nav so it fills the viewport edge-to-edge.
+   All other pages rely on body { padding-top: var(--header-height) } above. */
+body.home .hero {
+  margin-top: calc(-1 * var(--header-height));
 }
 
 body.admin-bar {


### PR DESCRIPTION
## MJM-186: Nav persistent scroll behaviour

### Problem
- `body:not(.home)` rule referenced undefined `--site-header-offset` CSS variable
- This caused non-home pages (posts, about, gear, archive) to lose their `padding-top` offset
- Page content would render behind/under the fixed nav, overlapping awkwardly

### Fix
- Removed the broken `body:not(.home)` rule — all pages now correctly inherit `body { padding-top: var(--header-height) }` from MJM-176
- Added `body.home .hero { margin-top: calc(-1 * var(--header-height)) }` so the homepage hero extends edge-to-edge behind the fixed nav (100vh hero design)

### Existing sticky nav infrastructure (unchanged, verified working)
- `position: fixed; top: 0; z-index: 1000` on `.site-nav` (design-system.css)
- Solid green background with backdrop blur (MJM-182 in style.css)  
- JS dynamically syncs `--header-height` from actual nav height (main.js)
- `scroll-margin-top` and `scroll-padding-top` for anchor link offsets
- Mobile responsive: 60px header at ≤782px, 72px on desktop
- Admin bar offset handled via `body.admin-bar` rules