### PR TITLE
feat(MJM-122): Add Instagram icon to social block

### DIFF
--- a/assets/css/design-system.css
+++ b/assets/css/design-system.css
@@ -1150,6 +1150,11 @@ figcaption {
   align-items: center;
   justify-content: center;
 }
+.site-footer__social-icon-svg {
+  width: 20px;
+  height: 20px;
+  display: block;
+}
 .site-footer__social-icon:hover { color: var(--color-text-inverse); }
 .site-footer__col-title {
   font-family: var(--font-body);

--- a/footer.php
+++ b/footer.php
@@ -23,7 +23,7 @@
                     <?php echo rr_social_links(); ?>
                     <?php // Fallback if no social links set in customizer ?>
                     <?php if ( ! get_theme_mod( 'rr_social_instagram' ) ) : ?>
-                        <a href="https://www.instagram.com/rolling_reno/" class="site-footer__social-icon" rel="noopener noreferrer" target="_blank" aria-label="<?php esc_attr_e( 'Follow Rolling Reno on Instagram', 'rolling-reno' ); ?>">📷</a>
+                        <a href="https://www.instagram.com/rollingreno/" class="site-footer__social-icon" rel="noopener noreferrer" target="_blank" aria-label="<?php esc_attr_e( 'Follow Rolling Reno on Instagram', 'rolling-reno' ); ?>"><?php echo rr_social_instagram_svg(); ?></a>
                         <a href="https://www.pinterest.com/rolling_reno/" class="site-footer__social-icon" rel="noopener noreferrer" target="_blank" aria-label="<?php esc_attr_e( 'Follow Rolling Reno on Pinterest', 'rolling-reno' ); ?>">📌</a>
                     <?php endif; ?>
                 </div>

--- a/functions.php
+++ b/functions.php
@@ -425,9 +425,13 @@ function rr_breadcrumb() {
 
 // ─── Social links helper ─────────────────────────────────────────────────────
 
+function rr_social_instagram_svg() {
+    return '<svg class="site-footer__social-icon-svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false" xmlns="http://www.w3.org/2000/svg"><rect x="3" y="3" width="18" height="18" rx="5" ry="5" fill="none" stroke="currentColor" stroke-width="2"/><circle cx="12" cy="12" r="4" fill="none" stroke="currentColor" stroke-width="2"/><circle cx="17.5" cy="6.5" r="1.2" fill="currentColor"/></svg>';
+}
+
 function rr_social_links() {
     $platforms = array(
-        'instagram' => array( 'label' => 'Instagram', 'icon' => '📷' ),
+        'instagram' => array( 'label' => 'Instagram', 'icon' => rr_social_instagram_svg() ),
         'pinterest' => array( 'label' => 'Pinterest',  'icon' => '📌' ),
         'youtube'   => array( 'label' => 'YouTube',    'icon' => '▶️' ),
         'tiktok'    => array( 'label' => 'TikTok',     'icon' => '🎵' ),


### PR DESCRIPTION
Closes MJM-122

Adds the Instagram icon to the footer social block, links to https://www.instagram.com/rollingreno/, opens in a new tab, and matches the existing social icon sizing/style. This branch also retains the staging deploy workflow commit already on the branch.