### PR TITLE
fix: correct affiliate disclosure footer URL

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -127,7 +127,7 @@ function rr_footer_connect_fallback() {
 function rr_footer_resources_fallback() {
     $links = array(
         array( home_url( '/free-guide' ),            __( 'Free Build Starter Kit', 'rolling-reno' ) ),
-        array( home_url( '/affiliate-disclosure' ),  __( 'Affiliate Disclosure',  'rolling-reno' ) ),
+        array( home_url( '/affiliate-disclosure/' ), __( 'Affiliate Disclosure', 'rolling-reno' ) ),
         array( home_url( '/privacy-policy' ),        __( 'Privacy Policy',        'rolling-reno' ) ),
         array( home_url( '/sitemap.xml' ),           __( 'Sitemap',               'rolling-reno' ) ),
     );


### PR DESCRIPTION
## Summary
- confirm the affiliate disclosure page already exists in production as published page ID 78
- update the footer fallback link to use `/affiliate-disclosure/`
- preserve existing page target instead of creating duplicate content

## Testing
- php -l footer.php