### PR TITLE
feat(MJM-156): add ConvertKit capture points

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -248,6 +248,7 @@ $cat_sub     = $cat_info['sub'];
             </div>
             <form class="cta-banner__form" action="<?php echo rr_newsletter_action(); ?>" method="POST">
                 <?php wp_nonce_field( 'rr_newsletter', 'rr_nonce' ); ?>
+                <?php rr_newsletter_hidden_fields(); ?>
                 <input type="email" name="email" placeholder="<?php esc_attr_e( 'Your email address', 'rolling-reno' ); ?>" required autocomplete="email" class="cta-banner__input" aria-label="<?php esc_attr_e( 'Email address', 'rolling-reno' ); ?>">
                 <button type="submit" class="btn--cta-banner"><?php esc_html_e( 'Send me the kit →', 'rolling-reno' ); ?></button>
                 <p class="cta-banner__fine"><?php esc_html_e( 'No spam. Unsubscribe any time.', 'rolling-reno' ); ?></p>

--- a/footer.php
+++ b/footer.php
@@ -113,7 +113,7 @@ function rr_footer_explore_fallback() {
 function rr_footer_connect_fallback() {
     $links = array(
         array( home_url( '/about' ),       __( 'About Mara',     'rolling-reno' ) ),
-        array( home_url( '/newsletter' ),  __( 'Newsletter',      'rolling-reno' ) ),
+        array( home_url( '/#newsletter' ),  __( 'Newsletter',      'rolling-reno' ) ),
         array( home_url( '/work-with-me' ),__( 'Work With Me',   'rolling-reno' ) ),
         array( home_url( '/contact' ),     __( 'Contact',        'rolling-reno' ) ),
     );

--- a/front-page.php
+++ b/front-page.php
@@ -335,7 +335,7 @@ $mara_about_img = get_theme_mod( 'rr_mara_about_image', '' );
 </section>
 
 <!-- ── Section 8: Lead Magnet / Email Opt-in ───────────────────────────── -->
-<section class="cta-banner cta-banner--leadmagnet" aria-labelledby="leadmagnet-heading">
+<section class="cta-banner cta-banner--leadmagnet" id="newsletter" aria-labelledby="leadmagnet-heading">
     <div class="cta-banner__inner container">
         <div class="cta-banner__text">
             <h2 class="cta-banner__heading" id="leadmagnet-heading">

--- a/header.php
+++ b/header.php
@@ -59,7 +59,7 @@
             </button>
 
             <!-- CTA pill — hide on mobile (shown in mobile menu) -->
-            <a href="/newsletter" class="btn btn--nav-cta hide-mobile">
+            <a href="<?php echo esc_url( home_url( '/#newsletter' ) ); ?>" class="btn btn--nav-cta hide-mobile">
                 <?php esc_html_e( 'Free Guide →', 'rolling-reno' ); ?>
             </a>
 
@@ -92,7 +92,7 @@
             ) );
             ?>
         </nav>
-        <a href="/newsletter" class="btn btn--primary" style="margin-top: 24px; display:block; text-align:center;">
+        <a href="<?php echo esc_url( home_url( '/#newsletter' ) ); ?>" class="btn btn--primary" style="margin-top: 24px; display:block; text-align:center;">
             <?php esc_html_e( 'Get the Free Guide →', 'rolling-reno' ); ?>
         </a>
     </div>

--- a/home.php
+++ b/home.php
@@ -60,6 +60,36 @@ get_header();
             <?php endif; ?>
         </div>
 
+        <section class="cta-banner cta-banner--leadmagnet" id="newsletter" aria-labelledby="blog-newsletter-heading">
+            <div class="cta-banner__inner">
+                <div class="cta-banner__text">
+                    <h2 class="cta-banner__heading" id="blog-newsletter-heading">
+                        <?php esc_html_e( "Get Mara's Free Van Build Starter Kit", 'rolling-reno' ); ?>
+                    </h2>
+                    <p class="cta-banner__sub">
+                        <?php esc_html_e( 'The exact checklist from Build #1 — tools, materials, costs, mistakes to avoid. Start your own conversion with fewer surprises.', 'rolling-reno' ); ?>
+                    </p>
+                </div>
+                <form class="cta-banner__form" action="<?php echo rr_newsletter_action(); ?>" method="POST">
+                    <?php wp_nonce_field( 'rr_newsletter', 'rr_nonce' ); ?>
+                    <?php rr_newsletter_hidden_fields(); ?>
+                    <input
+                        type="email"
+                        name="email"
+                        placeholder="<?php esc_attr_e( 'Your email address', 'rolling-reno' ); ?>"
+                        required
+                        autocomplete="email"
+                        class="cta-banner__input"
+                        aria-label="<?php esc_attr_e( 'Email address', 'rolling-reno' ); ?>"
+                    >
+                    <button type="submit" class="btn--cta-banner">
+                        <?php esc_html_e( 'Send me the kit →', 'rolling-reno' ); ?>
+                    </button>
+                    <p class="cta-banner__fine"><?php esc_html_e( 'No spam. Unsubscribe any time.', 'rolling-reno' ); ?></p>
+                </form>
+            </div>
+        </section>
+
         <?php the_posts_pagination( array(
             'mid_size'  => 2,
             'prev_text' => '← ' . __( 'Newer posts', 'rolling-reno' ),

--- a/page-about.php
+++ b/page-about.php
@@ -238,7 +238,7 @@ $gallery_bg = array( '#3D5A47', '#4A6741', '#2C4234', '#C4714A' );
                 <a href="<?php echo esc_url( home_url( '/start-here' ) ); ?>" class="btn btn--primary btn--lg">
                     <?php esc_html_e( 'Start Here →', 'rolling-reno' ); ?>
                 </a>
-                <a href="<?php echo esc_url( home_url( '/newsletter' ) ); ?>" class="btn btn--ghost btn--lg">
+                <a href="<?php echo esc_url( home_url( '/#newsletter' ) ); ?>" class="btn btn--ghost btn--lg">
                     <?php esc_html_e( 'Get the free guide →', 'rolling-reno' ); ?>
                 </a>
             </div>

--- a/page-gear.php
+++ b/page-gear.php
@@ -376,6 +376,7 @@ get_header();
             </div>
             <form class="cta-banner__form" action="<?php echo rr_newsletter_action(); ?>" method="POST">
                 <?php wp_nonce_field( 'rr_newsletter', 'rr_nonce' ); ?>
+                <?php rr_newsletter_hidden_fields(); ?>
                 <input type="email" name="email" placeholder="<?php esc_attr_e( 'Your email address', 'rolling-reno' ); ?>" required autocomplete="email" class="cta-banner__input" aria-label="<?php esc_attr_e( 'Email address', 'rolling-reno' ); ?>">
                 <button type="submit" class="btn--cta-banner"><?php esc_html_e( 'Send me the checklist →', 'rolling-reno' ); ?></button>
                 <p class="cta-banner__fine"><?php esc_html_e( 'No spam. Unsubscribe any time.', 'rolling-reno' ); ?></p>


### PR DESCRIPTION
## Summary
- add the blog index (/blog) lead-magnet opt-in form wired to existing ConvertKit/AJAX helpers
- add the missing hidden AJAX action field to archive and gear newsletter forms
- anchor the homepage opt-in as `#newsletter` and route broken `/newsletter` CTAs there

## Validation
- `php -l archive.php footer.php front-page.php header.php home.php page-about.php page-gear.php`
- inspected newsletter forms: all templates using `rr_newsletter_action()` now include `rr_newsletter_hidden_fields()`
- inspected links: no remaining hard-coded `/newsletter` links in theme PHP

Linear: MJM-156