### PR TITLE
fix(MJM-224): disable dead gear affiliate links

### DIFF
--- a/page-gear.php
+++ b/page-gear.php
@@ -238,8 +238,10 @@ get_header();
             <div class="gear-grid">
                 <?php foreach ( $section['products'] as $product ) :
                     $product['shop_url'] = function_exists( 'rr_affiliate_url' ) ? rr_affiliate_url( $product['shop_url'] ) : $product['shop_url'];
+                    $has_shop_url        = ! empty( $product['shop_url'] ) && '#' !== $product['shop_url'];
                 ?>
                 <div class="gear-product-card">
+                    <?php if ( $has_shop_url ) : ?>
                     <a
                         href="<?php echo esc_url( $product['shop_url'] ); ?>"
                         class="gear-product-card__image-link"
@@ -247,12 +249,19 @@ get_header();
                         target="_blank"
                         aria-label="<?php echo esc_attr( sprintf( __( 'Shop %s on Amazon (affiliate link)', 'rolling-reno' ), $product['name'] ) ); ?>"
                     >
+                    <?php else : ?>
+                    <div class="gear-product-card__image-link" aria-hidden="true">
+                    <?php endif; ?>
                         <div class="gear-product-card__image-wrap">
                             <div class="gear-product-card__image-placeholder" aria-hidden="true">
                                 <?php echo $product['emoji']; ?>
                             </div>
                         </div>
+                    <?php if ( $has_shop_url ) : ?>
                     </a>
+                    <?php else : ?>
+                    </div>
+                    <?php endif; ?>
                     <div class="gear-product-card__body">
                         <span class="badge badge--category"><?php echo esc_html( $product['badge'] ); ?></span>
                         <h3 class="gear-product-card__name"><?php echo esc_html( $product['name'] ); ?></h3>
@@ -261,7 +270,7 @@ get_header();
                             <span class="gear-product-card__price"><?php echo esc_html( $product['price'] ); ?></span>
                         </div>
                         <p class="gear-product-card__verdict"><?php echo esc_html( $product['verdict'] ); ?></p>
-                        <?php if ( $product['shop_url'] !== '#' ) : ?>
+                        <?php if ( $has_shop_url ) : ?>
                         <a
                             href="<?php echo esc_url( $product['shop_url'] ); ?>"
                             class="gear-product-card__cta"
@@ -273,7 +282,7 @@ get_header();
                         </a>
                         <?php else : ?>
                         <span class="gear-product-card__cta" style="color: var(--color-text-muted); cursor: default;">
-                            <?php esc_html_e( 'Link coming soon', 'rolling-reno' ); ?>
+                            <?php esc_html_e( 'Product link coming soon', 'rolling-reno' ); ?>
                         </span>
                         <?php endif; ?>
                     </div>


### PR DESCRIPTION
## Summary
- stop rendering placeholder gear product images as clickable affiliate links when `shop_url` is still `#`
- reuse a single `$has_shop_url` guard for both image and CTA actions
- clarify the placeholder CTA copy to `Product link coming soon`

## Context
- MJM-223 research output was not available in this session yet, so this PR is the smallest safe scaffolding change only
- avoids shipping fake/dead affiliate interactions while product sourcing is still pending

## Validation
- `php -l page-gear.php`