### PR TITLE
fix(MJM-221): replace broken Gear page content links

### DIFF
--- a/page-about.php
+++ b/page-about.php
@@ -119,7 +119,7 @@ $gallery_bg = array( '#3D5A47', '#4A6741', '#2C4234', '#C4714A' );
         <div class="container--narrow">
             <h2><?php esc_html_e( 'How I ended up here', 'rolling-reno' ); ?></h2>
             <div class="post-body" style="max-width: 100%; padding: 0;">
-                <h3><?php esc_html_e( 'The first van', 'rolling-reno' ); ?></h3>
+                <h3 id="build-renault-trafic"><?php esc_html_e( 'The first van', 'rolling-reno' ); ?></h3>
                 <p><?php esc_html_e( "It was a 2004 Renault Trafic with 210,000km on it and a suspicious smell I'd rather not describe. I paid €3,500 and immediately regretted it. Then I insulated it, which took three weekends and four trips to a German engineering forum, and immediately stopped regretting it.", 'rolling-reno' ); ?></p>
                 <p><?php esc_html_e( "I drove it to the Dingle Peninsula in September and parked up with a view I still haven't beaten. That was the moment I understood what this was about — not minimalism, not Instagram aesthetics, not sticking it to the system. Just the simplest possible version of being exactly where you want to be.", 'rolling-reno' ); ?></p>
 
@@ -130,8 +130,9 @@ $gallery_bg = array( '#3D5A47', '#4A6741', '#2C4234', '#C4714A' );
                     <p>"<?php esc_html_e( "I've slept in 12 countries and 200+ locations. The one thing I'm always asked is — how do I start? That's why this site exists.", 'rolling-reno' ); ?>"</p>
                 </blockquote>
 
-                <h3><?php esc_html_e( 'The first proper build', 'rolling-reno' ); ?></h3>
+                <h3 id="build-mercedes-sprinter"><?php esc_html_e( 'The first proper build', 'rolling-reno' ); ?></h3>
                 <p><?php esc_html_e( "Build #2 was a 2019 Mercedes Sprinter 313 LWB. I did it properly: Thinsulate insulation, 200W Renogy solar, 100Ah lithium, a Webasto diesel heater, and a kitchen I'm genuinely proud of. Total cost: €9,200. I documented every step because I couldn't find documentation I trusted online — and that documentation became this blog.", 'rolling-reno' ); ?></p>
+                <h3 id="build-autotrail-tribute"><?php esc_html_e( 'The current motorhome', 'rolling-reno' ); ?></h3>
                 <p><?php esc_html_e( "Build #3 is an Autotrail Tribute motorhome I picked up in 2024, which took everything I'd learned and applied it to a different format entirely. That's still ongoing.", 'rolling-reno' ); ?></p>
             </div>
 

--- a/page-gear.php
+++ b/page-gear.php
@@ -311,21 +311,21 @@ get_header();
                         'label' => __( 'Build 1', 'rolling-reno' ),
                         'name'  => __( 'Renault Trafic', 'rolling-reno' ),
                         'year'  => '2019',
-                        'url'   => home_url( '/van-life/renault-trafic-build' ),
+                        'url'   => home_url( '/about/#build-renault-trafic' ),
                         'emoji' => '🚐',
                     ),
                     array(
                         'label' => __( 'Build 2', 'rolling-reno' ),
                         'name'  => __( 'Mercedes Sprinter 313', 'rolling-reno' ),
                         'year'  => '2022',
-                        'url'   => home_url( '/van-life/sprinter-313-build' ),
+                        'url'   => home_url( '/about/#build-mercedes-sprinter' ),
                         'emoji' => '🚌',
                     ),
                     array(
                         'label' => __( 'Build 3', 'rolling-reno' ),
                         'name'  => __( 'Autotrail Tribute', 'rolling-reno' ),
                         'year'  => '2024',
-                        'url'   => home_url( '/rv-life/autotrail-tribute-build' ),
+                        'url'   => home_url( '/about/#build-autotrail-tribute' ),
                         'emoji' => '🏕️',
                     ),
                 );
@@ -356,12 +356,12 @@ get_header();
             <ul class="gear-guides__list">
                 <?php
                 $guides = array(
-                    array( home_url( '/gear/solar-panels-van-life' ),        __( 'Best Solar Panels for Van Life (UK/Ireland)', 'rolling-reno' ) ),
-                    array( home_url( '/van-life/12v-electrical-guide' ),      __( '12V Electrical System: Beginner\'s Guide', 'rolling-reno' ) ),
-                    array( home_url( '/van-life/insulation-guide' ),          __( 'Insulation Guide: What Actually Works in Irish Weather', 'rolling-reno' ) ),
-                    array( home_url( '/van-life/van-kitchen-build-guide' ),   __( 'The Van Kitchen Build Guide', 'rolling-reno' ) ),
-                    array( home_url( '/van-life/co-safety-van' ),             __( 'Carbon Monoxide Safety in a Van', 'rolling-reno' ) ),
-                    array( home_url( '/van-life/working-remotely-from-van' ), __( 'Working Remotely from a Van: What You Actually Need', 'rolling-reno' ) ),
+                    array( home_url( '/rv-solar-system-diy-guide/' ),             __( 'RV Solar System DIY: Panels, Sizing, and Off-Grid Power', 'rolling-reno' ) ),
+                    array( home_url( '/van-electrical-system-diy-guide/' ),       __( 'Van Electrical System DIY: The Complete 12V Wiring Guide', 'rolling-reno' ) ),
+                    array( home_url( '/van-insulation-guide/' ),                  __( 'Van Insulation: The Complete DIY Guide', 'rolling-reno' ) ),
+                    array( home_url( '/rv-van-kitchen-build-diy-guide/' ),        __( 'RV & Van Kitchen Build: Cooktops, Fridges, and Layout', 'rolling-reno' ) ),
+                    array( home_url( '/rv-van-ventilation-condensation-guide/' ), __( 'RV & Van Ventilation: Roof Fans, Condensation, and Air Flow', 'rolling-reno' ) ),
+                    array( home_url( '/rv-van-heating-options/' ),                __( 'RV & Van Heating: Diesel vs Propane vs Wood Stove', 'rolling-reno' ) ),
                 );
                 foreach ( $guides as $guide ) : ?>
                 <li class="gear-guides__item">


### PR DESCRIPTION
## Summary
- Replaced Gear page build cards that linked to nonexistent build pages with anchored links into the existing About page build-story content.
- Replaced six broken Gear deep-dive guide links with existing live guide URLs.
- Added About page heading anchors for the three build references.

## Audit evidence
- Crawled sitemap/nav/footer coverage: 58 Rolling Reno URLs.
- Broken Gear URLs fixed: /van-life/renault-trafic-build, /van-life/sprinter-313-build, /rv-life/autotrail-tribute-build, /gear/solar-panels-van-life, /van-life/12v-electrical-guide, /van-life/insulation-guide, /van-life/van-kitchen-build-guide, /van-life/co-safety-van, /van-life/working-remotely-from-van.
- Remaining issues are WP-managed content/taxonomy/config cleanup and are documented in the Linear comment.

## Validation
- php -l page-gear.php
- php -l page-about.php
- Verified all replacement target URLs return HTTP 200 on live site.
- Grep confirmed old broken Gear URLs are no longer present in theme PHP.

Linear: MJM-221