### PR TITLE
fix(MJM-242): bump asset version for nav hotfix

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -6,7 +6,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'RR_VERSION', '2.0.0' );
+define( 'RR_VERSION', '2.0.1' );
 define( 'RR_THEME_DIR', get_template_directory() );
 define( 'RR_THEME_URI', get_template_directory_uri() );
 

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI:         https://rollingreno.com
 Author:            Mara Collins / MJM Team
 Author URI:        https://rollingreno.com/about
 Description:       Wild Irish Editorial — magazine-quality van life blog theme for Rolling Reno. Redesigned v2 by Aoife & Lorcan (MJM-101).
-Version:           2.0.0
+Version:           2.0.1
 Requires at least: 6.0
 Tested up to:      6.5
 Requires PHP:      8.0


### PR DESCRIPTION
## Summary
- Bumps Rolling Reno theme asset version to 2.0.1 so browsers fetch the already-merged MJM-182 nav readability CSS.
- Keeps live scrollY=0 nav on the solid readable treatment.

## Validation
- php -l functions.php
- php -l header.php
- Deployed functions.php/style.css to Flywheel and flushed cache.
- Verified live style.css contains MJM-182 override.

Ticket: MJM-242