### PR TITLE
feat(MJM-249): build crawlable category hubs

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -1,33 +1,25 @@
 <?php
 /**
  * Rolling Reno v2 — archive.php
- * Category / archive hub page — spec: category-page-v2.md
+ * Crawlable category hub page — spec: category-page-v2.md
  */
 
 get_header();
 
-$queried_obj  = get_queried_object();
-$is_category  = is_category();
-$term_name    = $is_category ? single_cat_title( '', false ) : get_the_archive_title();
-$term_desc    = $is_category ? category_description() : get_the_archive_description();
-$post_count   = $is_category ? $queried_obj->count : false;
-
-// Category-specific config
-$cat_config = array(
-    'van-life'    => array( 'sub' => 'Guides, conversion diaries, and life on the road — from Ireland and beyond.', 'img_key' => 'rr_cat_img_van_life' ),
-    'rv-life'     => array( 'sub' => 'RV adventures, trip guides, and everything Mara has learned on the road.', 'img_key' => 'rr_cat_img_rv_life' ),
-    'gear'        => array( 'sub' => 'Tested, trusted gear — every recommendation backed by real-world use.', 'img_key' => 'rr_cat_img_gear' ),
-);
-
-$slug        = $is_category ? $queried_obj->slug : '';
-$cat_info    = isset( $cat_config[ $slug ] ) ? $cat_config[ $slug ] : array( 'sub' => $term_desc, 'img_key' => '' );
-$hero_img    = $cat_info['img_key'] ? get_theme_mod( $cat_info['img_key'], '' ) : '';
-$cat_sub     = $cat_info['sub'];
+$queried_obj = get_queried_object();
+$is_category = is_category();
+$slug        = ( $is_category && isset( $queried_obj->slug ) ) ? $queried_obj->slug : '';
+$hub_config  = function_exists( 'rr_category_hub_config_for_slug' ) ? rr_category_hub_config_for_slug( $slug ) : array();
+$term_name   = $is_category ? single_cat_title( '', false ) : get_the_archive_title();
+$term_desc   = $hub_config['intro'] ?? ( $is_category ? wp_strip_all_tags( category_description() ) : wp_strip_all_tags( get_the_archive_description() ) );
+$post_count  = ( $is_category && isset( $queried_obj->count ) ) ? (int) $queried_obj->count : false;
+$hero_img    = ! empty( $hub_config['img_key'] ) ? get_theme_mod( $hub_config['img_key'], '' ) : '';
+$cat_sub     = $hub_config['sub'] ?? $term_desc;
+$featured_slugs = $hub_config['featured_slugs'] ?? array();
 ?>
 
 <main id="main" role="main">
 
-    <!-- Category Hero -->
     <section class="category-hero" aria-label="<?php echo esc_attr( $term_name ); ?>">
         <?php if ( $hero_img ) : ?>
             <img
@@ -48,6 +40,8 @@ $cat_sub     = $cat_info['sub'];
             <nav class="category-hero__breadcrumb" aria-label="<?php esc_attr_e( 'Breadcrumb', 'rolling-reno' ); ?>">
                 <a href="<?php echo esc_url( home_url( '/' ) ); ?>"><?php esc_html_e( 'Home', 'rolling-reno' ); ?></a>
                 <span aria-hidden="true"> › </span>
+                <a href="<?php echo esc_url( home_url( '/blog/' ) ); ?>"><?php esc_html_e( 'Blog', 'rolling-reno' ); ?></a>
+                <span aria-hidden="true"> › </span>
                 <span><?php echo esc_html( $term_name ); ?></span>
             </nav>
             <h1 class="category-hero__title"><?php echo esc_html( $term_name ); ?></h1>
@@ -56,63 +50,55 @@ $cat_sub     = $cat_info['sub'];
             <?php endif; ?>
             <?php if ( $post_count ) : ?>
                 <p class="category-hero__count">
-                    <?php echo esc_html( sprintf( _n( '%d post in this category', '%d posts in this category', $post_count, 'rolling-reno' ), $post_count ) ); ?>
+                    <?php echo esc_html( sprintf( _n( '%d guide in this hub', '%d guides in this hub', $post_count, 'rolling-reno' ), $post_count ) ); ?>
                 </p>
             <?php endif; ?>
         </div>
     </section>
 
-    <!-- Category Intro Block -->
     <div class="container">
         <div class="category-intro">
             <?php if ( $term_desc ) : ?>
-                <p class="category-intro__text"><?php echo wp_kses_post( $term_desc ); ?></p>
+                <p class="category-intro__text"><?php echo esc_html( $term_desc ); ?></p>
             <?php endif; ?>
-            <?php
-            // Sub-category filter links (child categories)
-            if ( $is_category ) :
-                $child_cats = get_categories( array(
-                    'parent'  => $queried_obj->term_id,
-                    'hide_empty' => true,
-                ) );
-                if ( $child_cats ) : ?>
-            <div class="category-filters" role="list">
-                <a href="<?php echo esc_url( get_category_link( $queried_obj->term_id ) ); ?>" class="category-filter is-active" aria-current="page" role="listitem">
-                    <?php esc_html_e( 'All', 'rolling-reno' ); ?>
-                </a>
-                <?php foreach ( $child_cats as $child ) : ?>
-                <a href="<?php echo esc_url( get_category_link( $child->term_id ) ); ?>" class="category-filter" role="listitem">
-                    <?php echo esc_html( $child->name ); ?>
-                </a>
-                <?php endforeach; ?>
-            </div>
-                <?php endif;
-            endif; ?>
+
+            <?php if ( ! empty( $hub_config['next_steps'] ) ) : ?>
+                <div class="category-filters" role="list" aria-label="<?php esc_attr_e( 'Recommended next steps', 'rolling-reno' ); ?>">
+                    <?php foreach ( $hub_config['next_steps'] as $next_step ) : ?>
+                        <a href="<?php echo esc_url( home_url( $next_step['url'] ) ); ?>" class="category-filter" role="listitem">
+                            <?php echo esc_html( $next_step['label'] ); ?>
+                        </a>
+                    <?php endforeach; ?>
+                </div>
+            <?php endif; ?>
         </div>
     </div>
 
-    <!-- Pinned / Featured Post -->
     <?php
-    $pinned_query = new WP_Query( array(
-        'posts_per_page' => 1,
-        'cat'            => $is_category ? $queried_obj->term_id : 0,
-        'meta_key'       => '_rr_pinned',
-        'meta_value'     => '1',
-    ) );
-    if ( ! $pinned_query->have_posts() ) {
-        $pinned_query = new WP_Query( array(
-            'posts_per_page' => 1,
-            'cat'            => $is_category ? $queried_obj->term_id : 0,
-            'orderby'        => 'comment_count',
-        ) );
+    $featured_query_args = array(
+        'posts_per_page'      => $featured_slugs ? min( 3, count( $featured_slugs ) ) : 1,
+        'ignore_sticky_posts' => true,
+    );
+
+    if ( $featured_slugs ) {
+        $featured_query_args['post_name__in'] = $featured_slugs;
+        $featured_query_args['orderby']       = 'post_name__in';
+    } elseif ( $is_category ) {
+        $featured_query_args['cat']     = $queried_obj->term_id;
+        $featured_query_args['orderby'] = 'comment_count';
     }
-    if ( $pinned_query->have_posts() ) :
-        $pinned_query->the_post();
-        $p_thumb = rr_get_post_image_url( get_the_ID(), 'rr-card' );
+
+    $featured_query = new WP_Query( $featured_query_args );
+    if ( $featured_query->have_posts() ) :
     ?>
     <div class="container">
         <div class="pinned-post">
-            <span class="pinned-post__label"><?php esc_html_e( 'START HERE', 'rolling-reno' ); ?></span>
+            <span class="pinned-post__label"><?php esc_html_e( 'BEST PLACE TO START', 'rolling-reno' ); ?></span>
+            <?php
+            while ( $featured_query->have_posts() ) :
+                $featured_query->the_post();
+                $p_thumb = rr_get_post_image_url( get_the_ID(), 'rr-card' );
+            ?>
             <article class="featured-card" aria-labelledby="pinned-title-<?php the_ID(); ?>">
                 <div class="featured-card__image-wrap">
                     <?php if ( $p_thumb ) : ?>
@@ -131,7 +117,7 @@ $cat_sub     = $cat_info['sub'];
                 <div class="featured-card__body">
                     <div class="featured-card__meta">
                         <?php echo rr_category_badge(); ?>
-                        <span class="badge badge--pinned">📌 <?php esc_html_e( 'Pinned', 'rolling-reno' ); ?></span>
+                        <span class="badge badge--pinned">📌 <?php esc_html_e( 'Hub pick', 'rolling-reno' ); ?></span>
                         <span class="label-text"><?php echo esc_html( rr_read_time() ); ?></span>
                     </div>
                     <h2 class="featured-card__title" id="pinned-title-<?php the_ID(); ?>">
@@ -143,6 +129,7 @@ $cat_sub     = $cat_info['sub'];
                     </a>
                 </div>
             </article>
+            <?php endwhile; ?>
         </div>
     </div>
     <?php
@@ -150,11 +137,10 @@ $cat_sub     = $cat_info['sub'];
     wp_reset_postdata();
     ?>
 
-    <!-- Posts Grid -->
     <div class="container">
         <div class="category-posts">
             <div class="category-posts__header">
-                <h2 class="category-posts__heading"><?php esc_html_e( 'All Posts', 'rolling-reno' ); ?></h2>
+                <h2 class="category-posts__heading"><?php esc_html_e( 'All Guides', 'rolling-reno' ); ?></h2>
                 <div class="category-posts__sort">
                     <span><?php esc_html_e( 'Sort by:', 'rolling-reno' ); ?></span>
                     <a href="<?php echo esc_url( add_query_arg( 'orderby', 'date', get_pagenum_link() ) ); ?>" class="is-active">
@@ -166,7 +152,7 @@ $cat_sub     = $cat_info['sub'];
                 </div>
             </div>
 
-            <section class="category-posts__grid" aria-label="<?php echo esc_attr( sprintf( __( 'Posts in %s', 'rolling-reno' ), $term_name ) ); ?>">
+            <section class="category-posts__grid" aria-label="<?php echo esc_attr( sprintf( __( 'Guides in %s', 'rolling-reno' ), $term_name ) ); ?>">
                 <?php
                 if ( have_posts() ) :
                     while ( have_posts() ) :
@@ -197,13 +183,12 @@ $cat_sub     = $cat_info['sub'];
                 <?php
                     endwhile;
                 else : ?>
-                    <p><?php esc_html_e( 'No posts found.', 'rolling-reno' ); ?></p>
+                    <p><?php esc_html_e( 'No guides found.', 'rolling-reno' ); ?></p>
                 <?php endif; ?>
             </section>
 
-            <!-- Pagination -->
             <?php if ( $GLOBALS['wp_query']->max_num_pages > 1 ) : ?>
-            <nav class="category-posts__pagination" aria-label="<?php esc_attr_e( 'Post navigation', 'rolling-reno' ); ?>">
+            <nav class="category-posts__pagination" aria-label="<?php esc_attr_e( 'Guide navigation', 'rolling-reno' ); ?>">
                 <?php
                 $pages = paginate_links( array(
                     'type'      => 'array',
@@ -212,8 +197,6 @@ $cat_sub     = $cat_info['sub'];
                 ) );
                 if ( $pages ) :
                     foreach ( $pages as $page ) :
-                        $is_current = str_contains( $page, 'current' );
-                        // Wrap in nav link
                         echo str_replace(
                             array( 'page-numbers', 'prev page-numbers', 'next page-numbers', 'current' ),
                             array( 'pagination__item', 'pagination__item pagination__item--prev', 'pagination__item pagination__item--next', 'pagination__item is-current' ),
@@ -225,32 +208,21 @@ $cat_sub     = $cat_info['sub'];
             </nav>
             <?php endif; ?>
 
-        </div><!-- /.category-posts -->
-    </div><!-- /.container -->
+        </div>
+    </div>
 
-    <!-- Category Lead Magnet (van-life + gear only) -->
-    <?php if ( in_array( $slug, array( 'van-life', 'gear' ) ) ) : ?>
+    <?php if ( ! empty( $hub_config['cta'] ) ) : ?>
     <section class="cta-banner cta-banner--leadmagnet" aria-labelledby="cat-leadmagnet-heading">
         <div class="cta-banner__inner container">
             <div class="cta-banner__text">
-                <h2 class="cta-banner__heading" id="cat-leadmagnet-heading">
-                    <?php
-                    if ( $slug === 'van-life' ) {
-                        esc_html_e( "Van lifer? Get Mara's free Conversion Checklist.", 'rolling-reno' );
-                    } else {
-                        esc_html_e( "Want Mara's gear buying checklist?", 'rolling-reno' );
-                    }
-                    ?>
-                </h2>
-                <p class="cta-banner__sub">
-                    <?php esc_html_e( "Before your first build, read this. It's free, and it'll save you hundreds.", 'rolling-reno' ); ?>
-                </p>
+                <h2 class="cta-banner__heading" id="cat-leadmagnet-heading"><?php echo esc_html( $hub_config['cta']['heading'] ); ?></h2>
+                <p class="cta-banner__sub"><?php echo esc_html( $hub_config['cta']['text'] ); ?></p>
             </div>
             <form class="cta-banner__form" action="<?php echo rr_newsletter_action(); ?>" method="POST">
                 <?php wp_nonce_field( 'rr_newsletter', 'rr_nonce' ); ?>
                 <?php rr_newsletter_hidden_fields( 'category_archive_cta' ); ?>
                 <input type="email" name="email" placeholder="<?php esc_attr_e( 'Your email address', 'rolling-reno' ); ?>" required autocomplete="email" class="cta-banner__input" aria-label="<?php esc_attr_e( 'Email address', 'rolling-reno' ); ?>">
-                <button type="submit" class="btn--cta-banner"><?php esc_html_e( 'Send me the kit →', 'rolling-reno' ); ?></button>
+                <button type="submit" class="btn--cta-banner"><?php echo esc_html( $hub_config['cta']['label'] ); ?></button>
                 <p class="cta-banner__fine"><?php esc_html_e( 'No spam. Unsubscribe any time.', 'rolling-reno' ); ?></p>
             </form>
         </div>

--- a/archive.php
+++ b/archive.php
@@ -4,6 +4,11 @@
  * Crawlable category hub page — spec: category-page-v2.md
  */
 
+if ( is_category( 'uncategorized' ) ) {
+    wp_safe_redirect( home_url( '/blog/' ), 301 );
+    exit;
+}
+
 get_header();
 
 $queried_obj = get_queried_object();
@@ -11,7 +16,7 @@ $is_category = is_category();
 $slug        = ( $is_category && isset( $queried_obj->slug ) ) ? $queried_obj->slug : '';
 $hub_config  = function_exists( 'rr_category_hub_config_for_slug' ) ? rr_category_hub_config_for_slug( $slug ) : array();
 $term_name   = $is_category ? single_cat_title( '', false ) : get_the_archive_title();
-$term_desc   = $hub_config['intro'] ?? ( $is_category ? wp_strip_all_tags( category_description() ) : wp_strip_all_tags( get_the_archive_description() ) );
+$term_desc   = $hub_config['intro'] ?? ( $is_category ? wp_strip_all_tags( html_entity_decode( category_description(), ENT_QUOTES, get_bloginfo( 'charset' ) ) ) : wp_strip_all_tags( html_entity_decode( get_the_archive_description(), ENT_QUOTES, get_bloginfo( 'charset' ) ) ) );
 $post_count  = ( $is_category && isset( $queried_obj->count ) ) ? (int) $queried_obj->count : false;
 $hero_img    = ! empty( $hub_config['img_key'] ) ? get_theme_mod( $hub_config['img_key'], '' ) : '';
 $cat_sub     = $hub_config['sub'] ?? $term_desc;

--- a/functions.php
+++ b/functions.php
@@ -259,6 +259,131 @@ function rr_get_post_image_url( $post_id = null, $size = 'full' ) {
     return '';
 }
 
+
+// ─── Category Hub Content & SEO ─────────────────────────────────────────────
+
+function rr_category_hub_config() {
+    return array(
+        'start-here-planning' => array(
+            'sub'            => 'Start with the order of operations: inspect the rig, plan the budget, then build without expensive re-dos.',
+            'intro'          => 'New to RV renovation? Start here. These guides cover inspection, budgeting, renovation order, common mistakes, and the decisions that save money before you buy materials.',
+            'seo_title'      => 'Start Here & Planning RV Renovation Guides',
+            'seo_desc'       => 'Plan a practical RV renovation with guides to inspection, budgeting, renovation order, common mistakes, and beginner-friendly build decisions.',
+            'featured_slugs' => array( 'diy-rv-renovation-guide-start-here', 'how-renovate-rv-right-order', 'rv-renovation-cost-breakdown' ),
+            'next_steps'     => array(
+                array( 'label' => 'Inspection checklist', 'url' => '/used-rv-inspection-checklist/' ),
+                array( 'label' => 'Renovation order', 'url' => '/how-renovate-rv-right-order/' ),
+                array( 'label' => 'Cost breakdown', 'url' => '/rv-renovation-cost-breakdown/' ),
+            ),
+            'cta'            => array( 'heading' => 'Not sure where to start?', 'text' => 'Use the beginner guides first, then move into systems, interiors, and vehicle choices once the plan is solid.', 'label' => 'Read the start-here guide →', 'url' => '/diy-rv-renovation-guide-start-here/' ),
+        ),
+        'vehicle-guides' => array(
+            'sub'            => 'Compare vans, older RVs, minivans, electric vans, and buyer trade-offs before committing to a rig.',
+            'intro'          => 'Choosing the wrong base vehicle can make every later renovation harder. This hub helps you compare models, spot practical trade-offs, and match the rig to your budget, travel style, and build plan.',
+            'seo_title'      => 'Vehicle Guides for RV and Van Renovation',
+            'seo_desc'       => 'Compare vans, older RVs, minivans, electric vans, and buyer considerations before choosing a renovation project.',
+            'featured_slugs' => array( 'best-vans-rvs-to-renovate-buyers-guide', 'best-older-rvs-to-renovate', 'used-rv-inspection-checklist' ),
+            'next_steps'     => array(
+                array( 'label' => 'Buyer guide', 'url' => '/best-vans-rvs-to-renovate-buyers-guide/' ),
+                array( 'label' => 'Older RV picks', 'url' => '/best-older-rvs-to-renovate/' ),
+                array( 'label' => 'Used RV inspection', 'url' => '/used-rv-inspection-checklist/' ),
+            ),
+            'cta'            => array( 'heading' => 'Buying before building?', 'text' => 'Check for water damage and layout constraints before you price paint, flooring, or solar.', 'label' => 'Use the inspection checklist →', 'url' => '/used-rv-inspection-checklist/' ),
+        ),
+        'systems-off-grid' => array(
+            'sub'            => 'Electrical, solar, plumbing, heating, ventilation, and off-grid systems explained in plain language.',
+            'intro'          => 'Systems are where RV renovations get expensive fast. Use these guides to plan power, water, heat, ventilation, and off-grid upgrades before the walls and cabinets close everything in.',
+            'seo_title'      => 'RV Systems & Off-Grid Guides',
+            'seo_desc'       => 'Practical RV and van guides for solar, electrical, plumbing, heating, ventilation, water systems, and off-grid planning.',
+            'featured_slugs' => array( 'van-electrical-system-diy-guide', 'rv-solar-system-diy-guide', 'rv-water-system-diy-guide' ),
+            'next_steps'     => array(
+                array( 'label' => 'Electrical guide', 'url' => '/van-electrical-system-diy-guide/' ),
+                array( 'label' => 'Solar sizing', 'url' => '/rv-solar-system-diy-guide/' ),
+                array( 'label' => 'Water systems', 'url' => '/rv-water-system-diy-guide/' ),
+            ),
+            'cta'            => array( 'heading' => 'Plan systems before cabinets.', 'text' => 'Map wires, water lines, vents, and access panels early so finished work does not have to be cut open later.', 'label' => 'Start with electrical →', 'url' => '/van-electrical-system-diy-guide/' ),
+        ),
+        'interior-build-layouts' => array(
+            'sub'            => 'Kitchens, bathrooms, beds, storage, flooring, paint, insulation, and layout choices for real road use.',
+            'intro'          => 'Interior choices decide how the rig feels every day. This hub covers the practical parts: layout trade-offs, flooring, paint, kitchens, bathrooms, storage, beds, insulation, and materials that hold up on the road.',
+            'seo_title'      => 'RV Interior Build & Layout Guides',
+            'seo_desc'       => 'RV and van interior renovation guides for layouts, kitchens, bathrooms, beds, storage, flooring, paint, insulation, and lightweight materials.',
+            'featured_slugs' => array( 'rv-van-kitchen-build-diy-guide', 'rv-van-bed-build-diy', 'best-lightweight-materials-rv-remodel' ),
+            'next_steps'     => array(
+                array( 'label' => 'Kitchen build', 'url' => '/rv-van-kitchen-build-diy-guide/' ),
+                array( 'label' => 'Bed layouts', 'url' => '/rv-van-bed-build-diy/' ),
+                array( 'label' => 'Lightweight materials', 'url' => '/best-lightweight-materials-rv-remodel/' ),
+            ),
+            'cta'            => array( 'heading' => 'Make the layout earn its space.', 'text' => 'Start with the daily-use zones — bed, kitchen, bathroom, storage — before choosing finishes.', 'label' => 'Compare bed layouts →', 'url' => '/rv-van-bed-build-diy/' ),
+        ),
+        'van-life' => array(
+            'sub'            => 'Road-life logistics, domicile, mental health, routines, and practical full-time van living decisions.',
+            'intro'          => 'Van life is not just scenic pull-offs. This hub covers the admin, routines, mental load, and full-time logistics that make life on the road work after the build is finished.',
+            'seo_title'      => 'Practical Van Life Guides',
+            'seo_desc'       => 'Practical van life guides for domicile, full-time logistics, mental health, routines, and living on the road after the build.',
+            'featured_slugs' => array( 'van-life-domicile-which-state-should-you-call-home', 'van-life-mental-health-what-nobody-talks-about', 'the-3000-van-conversion-everything-you-need-nothing-you-dont' ),
+            'next_steps'     => array(
+                array( 'label' => 'Domicile guide', 'url' => '/van-life-domicile-which-state-should-you-call-home/' ),
+                array( 'label' => 'Mental health', 'url' => '/van-life-mental-health-what-nobody-talks-about/' ),
+                array( 'label' => '$3,000 build', 'url' => '/the-3000-van-conversion-everything-you-need-nothing-you-dont/' ),
+            ),
+            'cta'            => array( 'heading' => 'Living on the road needs a plan too.', 'text' => 'Sort domicile, insurance, routine, and mental load before the first long trip.', 'label' => 'Read the domicile guide →', 'url' => '/van-life-domicile-which-state-should-you-call-home/' ),
+        ),
+        'rv-life' => array(
+            'sub'            => 'Full-time RV logistics, insurance, healthcare, retirement-on-wheels, and practical ownership realities.',
+            'intro'          => 'RV life has its own paperwork, costs, coverage questions, and comfort trade-offs. This hub keeps the lifestyle advice grounded in real decisions, not brochure fantasy.',
+            'seo_title'      => 'RV Life Guides for Full-Time and Practical Travel',
+            'seo_desc'       => 'RV life guides covering full-time insurance, healthcare on the road, retirement-on-wheels, ownership logistics, and practical travel decisions.',
+            'featured_slugs' => array( 'full-time-rv-insurance', 'medicare-on-the-road-a-full-timers-healthcare-survival-guide', 'retirement-on-wheels-the-rv-conversion-guide-nobody-made-for-boomers' ),
+            'next_steps'     => array(
+                array( 'label' => 'RV insurance', 'url' => '/full-time-rv-insurance/' ),
+                array( 'label' => 'Healthcare', 'url' => '/medicare-on-the-road-a-full-timers-healthcare-survival-guide/' ),
+                array( 'label' => 'Retirement builds', 'url' => '/retirement-on-wheels-the-rv-conversion-guide-nobody-made-for-boomers/' ),
+            ),
+            'cta'            => array( 'heading' => 'Full-time RV life changes the paperwork.', 'text' => 'Insurance, healthcare, domicile, and emergency planning matter as much as the build itself.', 'label' => 'Start with insurance →', 'url' => '/full-time-rv-insurance/' ),
+        ),
+    );
+}
+
+function rr_category_hub_config_for_slug( $slug ) {
+    $config = rr_category_hub_config();
+    return $config[ $slug ] ?? array();
+}
+
+function rr_category_hub_document_title( $title ) {
+    if ( ! is_category() ) {
+        return $title;
+    }
+    $term = get_queried_object();
+    if ( ! $term || empty( $term->slug ) ) {
+        return $title;
+    }
+    $config = rr_category_hub_config_for_slug( $term->slug );
+    if ( empty( $config['seo_title'] ) ) {
+        return $title;
+    }
+    $title['title'] = $config['seo_title'];
+    $title['site']  = get_bloginfo( 'name' );
+    return $title;
+}
+add_filter( 'document_title_parts', 'rr_category_hub_document_title' );
+
+function rr_category_hub_meta_description() {
+    if ( ! is_category() ) {
+        return;
+    }
+    $term = get_queried_object();
+    if ( ! $term || empty( $term->slug ) ) {
+        return;
+    }
+    $config = rr_category_hub_config_for_slug( $term->slug );
+    if ( empty( $config['seo_desc'] ) ) {
+        return;
+    }
+    echo '<meta name="description" content="' . esc_attr( $config['seo_desc'] ) . '">' . "\n";
+}
+add_action( 'wp_head', 'rr_category_hub_meta_description', 2 );
+
 // ─── Preconnect & Preload (Google Fonts, hero image) ────────────────────────
 
 function rr_preconnect_fonts( $output, $rel, $url ) {

--- a/functions.php
+++ b/functions.php
@@ -6,7 +6,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'RR_VERSION', '2.0.1' );
+define( 'RR_VERSION', '2.0.2' );
 define( 'RR_THEME_DIR', get_template_directory() );
 define( 'RR_THEME_URI', get_template_directory_uri() );
 

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI:         https://rollingreno.com
 Author:            Mara Collins / MJM Team
 Author URI:        https://rollingreno.com/about
 Description:       Wild Irish Editorial — magazine-quality van life blog theme for Rolling Reno. Redesigned v2 by Aoife & Lorcan (MJM-101).
-Version:           2.0.1
+Version:           2.0.2
 Requires at least: 6.0
 Tested up to:      6.5
 Requires PHP:      8.0
@@ -113,4 +113,28 @@ h4[id] {
 .site-nav .site-nav__link[aria-current="page"] {
   color: var(--color-sand);
   border-bottom-color: var(--color-sand);
+}
+
+/* MJM-249: harden desktop Blog submenu hiding after category hub QA regression.
+   style.css loads after component CSS, so this guards against stale/overridden submenu rules. */
+@media (min-width: 1024px) {
+  .site-nav__item--has-menu > .site-nav__submenu {
+    position: absolute;
+    top: calc(100% + var(--space-3));
+    left: 50%;
+    z-index: 1001;
+    display: grid;
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+    transform: translateX(-50%) translateY(-6px);
+  }
+
+  .site-nav__item--has-menu:hover > .site-nav__submenu,
+  .site-nav__item--has-menu:focus-within > .site-nav__submenu {
+    opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
+    transform: translateX(-50%) translateY(0);
+  }
 }


### PR DESCRIPTION
## MJM-249 current release evidence

Latest fix pushed:
- Branch: `sarah/MJM-249-category-hubs`
- Head: `3f2cc42`
- Fix: hardened desktop Blog submenu so child links stay hidden until hover/focus, and bumped `RR_VERSION` / theme version to `2.0.2` so staging serves the updated CSS.
- Reason: Aoife UI/UX QA found the Blog child links visible inline in the desktop header.

Validation:
- `php -l archive.php` ✅
- `php -l functions.php` ✅
- `git diff --check` ✅
- Branch rebased onto current `origin/main` after MJM-250 merged ✅

Staging deploy:
- Latest staging deploy passed: https://github.com/MJM-Agents/rolling-reno-theme/actions/runs/24960114661
- Staging URL: https://rollingreno.flywheelstaging.com
- Privacy auth used for QA: `rollingreno` / `Privy123`

Staging evidence checked after latest deploy with cache-busting query:
- `/category/start-here-planning/` — HTTP 200; `BEST PLACE TO START`, `Hub pick`, `All Guides`, `meta name="description"`, `style.css?ver=2.0.2` present ✅
- `/category/vehicle-guides/` — HTTP 200; `BEST PLACE TO START`, `Hub pick`, `All Guides`, `meta name="description"`, `style.css?ver=2.0.2` present ✅
- `/category/systems-off-grid/` — HTTP 200; `BEST PLACE TO START`, `Hub pick`, `All Guides`, `meta name="description"`, `style.css?ver=2.0.2` present ✅
- `/category/interior-build-layouts/` — HTTP 200; `BEST PLACE TO START`, `Hub pick`, `All Guides`, `meta name="description"`, `style.css?ver=2.0.2` present ✅
- `/category/van-life/` — HTTP 200; `BEST PLACE TO START`, `Hub pick`, `All Guides`, `meta name="description"`, `style.css?ver=2.0.2` present ✅
- `/category/rv-life/` — HTTP 200; `BEST PLACE TO START`, `Hub pick`, `All Guides`, `meta name="description"`, `style.css?ver=2.0.2` present ✅
- Direct `style.css?ver=2.0.2` returned HTTP 200 and contains the MJM-249 submenu guard ✅

QA verdicts:
- Sarah copy QA: APPROVED ✅
- Sienna functional QA: APPROVED ✅
- Aoife UI/UX QA: CHANGES_REQUESTED before `3f2cc42`; re-check requested after the submenu fix ⏳

Rollback note:
- Revert PR #38 or commit `3f2cc42` to remove the category hub template changes/submenu guard if regression appears before merge.

Remaining blocker before merge/Done:
- Aoife must re-check the desktop header submenu on staging and either approve or leave exact remaining changes.
- Reviewer re-review/merge should happen only after Aoife clears the UI blocker.
