### PR TITLE
fix(MJM-268): align homepage hero with Mara brand

### DIFF
--- a/front-page.php
+++ b/front-page.php
@@ -21,7 +21,7 @@ $mara_about_img = get_theme_mod( 'rr_mara_about_image', '' );
         <img
             class="hero__image"
             src="<?php echo esc_url( $hero_img ); ?>"
-            alt="<?php esc_attr_e( 'Mara Collins with her converted van in the Irish countryside', 'rolling-reno' ); ?>"
+            alt="<?php esc_attr_e( 'Mara Collins standing beside her converted van in the countryside', 'rolling-reno' ); ?>"
             width="1920"
             height="1080"
             loading="eager"
@@ -30,8 +30,8 @@ $mara_about_img = get_theme_mod( 'rr_mara_about_image', '' );
     <?php else : ?>
         <img
             class="hero__image"
-            src="<?php echo get_template_directory_uri(); ?>/assets/images/mara-hero.jpg"
-            alt="<?php esc_attr_e( 'Mara Collins with her converted van in the Irish countryside', 'rolling-reno' ); ?>"
+            src="<?php echo get_template_directory_uri(); ?>/assets/images/hero-unsplash.jpg"
+            alt="<?php esc_attr_e( 'Mara Collins standing beside her converted van in the countryside', 'rolling-reno' ); ?>"
             width="1920"
             height="1080"
             loading="eager"


### PR DESCRIPTION
## Summary
- Replaces the default homepage hero image fallback from `mara-hero.jpg` to `hero-unsplash.jpg`.
- Removes the male/ambiguous silhouette behind homepage copy that says “I’m Mara”.
- Updates hero alt text to match the visible brand intent: Mara beside her converted van.

## Ticket
MJM-268
Parent gate: MJM-260

## Release QA evidence
- Acceptance criteria / expected outcome: homepage hero must not imply a male subject is Mara and must be consistent with the Mara-led RV/van renovation brand.
- Staging URL: https://rollingreno.flywheelstaging.com/ after deploy.
- Changed pages/components: homepage hero fallback in `front-page.php`.
- Functional validation: `php -l front-page.php` passes.
- Aoife UI/UX verdict: pending.
- Sarah copy/brand verdict: pending.
- Branch freshness: branched from `origin/main` after fetch on 2026-04-26.
- Rollback: revert this PR to restore previous fallback image behavior.

## Notes
Mike flagged the current homepage hero in Slack. Verified production and staging currently load `assets/images/mara-hero.jpg`, which reads as a male/ambiguous back-view silhouette while the copy says “I’m Mara.”
