### PR TITLE
fix(MJM-277): repair staging hero visual regression

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -36,12 +36,12 @@
 
 .hero {
   position: relative;
-  height: 100vh;
-  min-height: 600px;
+  min-height: 720px;
+  height: min(92vh, 860px);
   overflow: hidden;
   display: flex;
-  align-items: flex-end;
-  padding-bottom: var(--space-24);
+  align-items: center;
+  padding: var(--space-16) 0;
 }
 .hero__image {
   position: absolute;
@@ -49,7 +49,7 @@
   width: 100%;
   height: 100%;
   object-fit: cover;
-  object-position: center 30%;
+  object-position: 58% 42%;
   z-index: 0;
 }
 .hero__image-placeholder {
@@ -60,15 +60,19 @@
 .hero__overlay {
   position: absolute;
   inset: 0;
-  background: var(--gradient-hero-center);
+  background:
+    linear-gradient(90deg, rgba(20, 32, 26, 0.88) 0%, rgba(20, 32, 26, 0.68) 34%, rgba(20, 32, 26, 0.26) 68%, rgba(20, 32, 26, 0.12) 100%),
+    linear-gradient(180deg, rgba(20, 32, 26, 0.18) 0%, rgba(20, 32, 26, 0.42) 100%);
   z-index: 1;
 }
 .hero__content {
   position: relative;
   z-index: 2;
   width: 100%;
-  text-align: center;
-  padding: 0 var(--space-6);
+  max-width: 1180px;
+  margin: 0 auto;
+  text-align: left;
+  padding: 0 var(--space-8);
 }
 .hero__eyebrow {
   font-family: var(--font-body);
@@ -81,25 +85,25 @@
 }
 .hero__title {
   font-family: var(--font-display);
-  font-size: clamp(40px, 6.5vw, 72px);
+  font-size: clamp(40px, 5.4vw, 64px);
   font-weight: 300;
   line-height: 1.08;
   letter-spacing: -0.02em;
   color: var(--color-text-inverse);
-  margin: 0 auto var(--space-5);
-  max-width: 760px;
+  margin: 0 0 var(--space-5);
+  max-width: 640px;
 }
 .hero__sub {
   font-size: 18px;
   color: rgba(250, 250, 248, 0.80);
-  margin: 0 auto var(--space-8);
-  max-width: 500px;
+  margin: 0 0 var(--space-7);
+  max-width: 480px;
   line-height: 1.55;
 }
 .hero__ctas {
   display: flex;
   gap: var(--space-4);
-  justify-content: center;
+  justify-content: flex-start;
   flex-wrap: wrap;
 }
 .hero__scroll-indicator {
@@ -119,15 +123,49 @@
 
 @media (max-width: 768px) {
   .hero {
+    min-height: 680px;
     height: auto;
-    min-height: 80vh;
-    align-items: center;
-    padding: 120px var(--space-4) var(--space-16);
+    align-items: flex-end;
+    padding: 112px var(--space-4) var(--space-10);
   }
-  .hero__title { font-size: clamp(34px, 10vw, 52px); }
-  .hero__ctas { flex-direction: column; align-items: center; }
-  .hero__ctas .btn { width: 100%; max-width: 280px; }
+  .hero__image { object-position: 56% center; }
+  .hero__overlay {
+    background:
+      linear-gradient(180deg, rgba(20, 32, 26, 0.20) 0%, rgba(20, 32, 26, 0.58) 38%, rgba(20, 32, 26, 0.88) 100%);
+  }
+  .hero__content {
+    box-sizing: border-box;
+    width: min(320px, calc(100vw - 56px));
+    max-width: min(320px, calc(100vw - 56px));
+    margin: 0 auto;
+    padding: var(--space-5) var(--space-4);
+    text-align: center;
+    background: rgba(18, 30, 24, 0.74);
+    border: 1px solid rgba(250, 250, 248, 0.16);
+    border-radius: var(--radius-xl);
+    box-shadow: var(--shadow-lift);
+    backdrop-filter: blur(6px);
+    overflow: hidden;
+  }
+  .hero__eyebrow { font-size: 10px; margin-bottom: var(--space-3); }
+  .hero__title {
+    max-width: 100%;
+    font-size: clamp(21px, 5.8vw, 25px);
+    line-height: 1.14;
+    letter-spacing: -0.01em;
+    overflow-wrap: normal;
+    word-break: normal;
+  }
+  .hero__sub {
+    max-width: 100%;
+    font-size: 13px;
+    line-height: 1.42;
+    margin-bottom: var(--space-5);
+  }
+  .hero__ctas { flex-direction: column; align-items: stretch; gap: var(--space-3); }
+  .hero__ctas .btn { width: 100%; max-width: none; }
   .hero__scroll-indicator { display: none; }
+  .value-strip { padding: var(--space-6) 0; }
 }
 
 
@@ -238,8 +276,8 @@
   line-height: 1.5;
 }
 @media (max-width: 640px) {
-  .value-strip__grid { grid-template-columns: 1fr; }
-  .value-strip__item { padding: var(--space-4); }
+  .value-strip__grid { grid-template-columns: 1fr; gap: var(--space-2); }
+  .value-strip__item { padding: var(--space-3) var(--space-4); }
 }
 
 /* ═══════════════════════════════════════════════════════════

--- a/functions.php
+++ b/functions.php
@@ -6,7 +6,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'RR_VERSION', '2.0.2' );
+define( 'RR_VERSION', '2.0.3' );
 define( 'RR_THEME_DIR', get_template_directory() );
 define( 'RR_THEME_URI', get_template_directory_uri() );
 


### PR DESCRIPTION
## Summary
- Repairs the Wave 1 staging visual regression Mike reported on the homepage hero.
- Repositions desktop hero copy away from the image focal point and improves the localized overlay.
- Fixes mobile clipping by constraining the hero card, reducing mobile type scale, and tightening value-strip spacing.
- Bumps RR_VERSION from 2.0.2 to 2.0.3 so browsers receive the updated CSS instead of cached stale hero CSS.

## Release evidence
- Acceptance criteria / expected outcome: homepage hero must not look broken; desktop and mobile hero text must be readable and not clipped.
- Staging URL: https://rollingreno.flywheelstaging.com/?cache_bust=mjm277
- Changed pages/components/scripts: homepage hero CSS in assets/css/main.css; theme asset version in functions.php.
- Visual QA: PASS by Cian via Playwright screenshots; no clipped mobile text, no desktop severe visual regression.
- Functional QA: PASS by Cian; staging homepage HTTP 200, no horizontal overflow in Playwright (document width equals viewport on mobile and desktop).
- Branch freshness: branched from origin/main after #44/#45; deployed latest commit 5deea064 to staging.
- Rollback: revert PR #46 or redeploy main SHA 6a4af4be if needed.

Refs MJM-277