### PR TITLE
fix(MJM-282): harden CTA spacing search and nav

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -318,21 +318,44 @@
     window.addEventListener('scroll', throttle(updateProgress, 60), { passive: true });
   }
 
-  // ─── Search Button Placeholder ───────────────────────────────────────────────
+  // ─── Search Drawer ─────────────────────────────────────────────────
 
   function initSearchBtn() {
     const searchBtns = document.querySelectorAll('.site-nav__search-btn');
+    const drawer = document.getElementById('site-search');
+    if (!drawer) return;
+
+    const input = drawer.querySelector('.site-search__input');
+    const close = drawer.querySelector('.site-search__close');
+
+    function openSearch() {
+      drawer.setAttribute('aria-hidden', 'false');
+      document.body.classList.add('search-open');
+      searchBtns.forEach(btn => btn.setAttribute('aria-expanded', 'true'));
+      setTimeout(() => { if (input) input.focus(); }, 50);
+    }
+
+    function closeSearch() {
+      drawer.setAttribute('aria-hidden', 'true');
+      document.body.classList.remove('search-open');
+      searchBtns.forEach(btn => btn.setAttribute('aria-expanded', 'false'));
+    }
+
     searchBtns.forEach(function (btn) {
+      btn.setAttribute('aria-controls', 'site-search');
+      btn.setAttribute('aria-expanded', 'false');
       btn.addEventListener('click', function () {
-        // Trigger WordPress native search if available, else simple focus
-        const searchInput = document.querySelector('input[type="search"]');
-        if (searchInput) {
-          searchInput.focus();
+        if (drawer.getAttribute('aria-hidden') === 'false') {
+          closeSearch();
         } else {
-          // Attempt to navigate to search
-          window.location.href = '/?s=';
+          openSearch();
         }
       });
+    });
+
+    if (close) close.addEventListener('click', closeSearch);
+    document.addEventListener('keydown', function (event) {
+      if (event.key === 'Escape') closeSearch();
     });
   }
 

--- a/functions.php
+++ b/functions.php
@@ -6,7 +6,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'RR_VERSION', '2.0.5' );
+define( 'RR_VERSION', '2.0.6' );
 define( 'RR_THEME_DIR', get_template_directory() );
 define( 'RR_THEME_URI', get_template_directory_uri() );
 

--- a/header.php
+++ b/header.php
@@ -78,6 +78,17 @@
         </a>
     </div>
 </header>
+
+<!-- Search drawer -->
+<div class="site-search" id="site-search" aria-hidden="true">
+    <form class="site-search__form" role="search" method="get" action="<?php echo esc_url( home_url( '/' ) ); ?>">
+        <label class="sr-only" for="site-search-input"><?php esc_html_e( 'Search Rolling Reno', 'rolling-reno' ); ?></label>
+        <input id="site-search-input" class="site-search__input" type="search" name="s" placeholder="<?php esc_attr_e( 'Search guides, gear, insurance…', 'rolling-reno' ); ?>" autocomplete="off">
+        <button class="site-search__submit" type="submit"><?php esc_html_e( 'Search', 'rolling-reno' ); ?></button>
+        <button class="site-search__close" type="button" aria-label="<?php esc_attr_e( 'Close search', 'rolling-reno' ); ?>">×</button>
+    </form>
+</div>
+
 <!-- ── /Site Navigation ─────────────────────────────────────────────────── -->
 
 <?php // Nav walkers defined in functions.php — loaded before header.php ?>

--- a/style.css
+++ b/style.css
@@ -303,3 +303,104 @@ h4[id] {
 @media (min-width: 1024px) {
   .site-nav__submenu { display: none !important; }
 }
+
+
+/* MJM-282: harden nav/search and CTA spacing after staging QA failures. */
+.site-nav__links { overflow: hidden; }
+.site-nav__item--has-menu > .site-nav__submenu,
+.site-nav__submenu { display: none !important; }
+.site-search {
+  position: fixed;
+  top: var(--header-height);
+  left: 0;
+  right: 0;
+  z-index: 999;
+  background: rgba(250, 250, 248, 0.98);
+  border-bottom: 1px solid var(--color-border, #ded6c9);
+  box-shadow: 0 18px 45px rgba(44, 66, 52, 0.16);
+  padding: 16px max(20px, calc((100vw - 1180px) / 2));
+  transform: translateY(-130%);
+  opacity: 0;
+  pointer-events: none;
+  transition: transform 180ms ease, opacity 180ms ease;
+}
+.site-search[aria-hidden="false"] {
+  transform: translateY(0);
+  opacity: 1;
+  pointer-events: auto;
+}
+.site-search__form {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  gap: 12px;
+  align-items: center;
+}
+.site-search__input {
+  min-height: 48px;
+  width: 100%;
+  border: 1px solid var(--color-border-strong, #b8aa98);
+  border-radius: 12px;
+  padding: 0 16px;
+  font: inherit;
+  color: var(--color-text-primary, #282724);
+  background: #fff;
+}
+.site-search__submit,
+.site-search__close {
+  min-height: 48px;
+  border: 0;
+  border-radius: 12px;
+  cursor: pointer;
+  font-weight: 800;
+}
+.site-search__submit {
+  padding: 0 22px;
+  background: var(--color-terracotta, #c4714a);
+  color: #fff;
+}
+.site-search__close {
+  width: 48px;
+  background: var(--color-sand, #f1eadf);
+  color: var(--color-text-primary, #282724);
+  font-size: 26px;
+  line-height: 1;
+}
+@media (max-width: 640px) {
+  .site-search { padding: 12px 16px; }
+  .site-search__form { grid-template-columns: 1fr; }
+  .site-search__close { width: 100%; }
+}
+.cta-banner--leadmagnet {
+  border-radius: 22px;
+  margin-left: auto;
+  margin-right: auto;
+  max-width: 1120px;
+  min-height: 0 !important;
+  padding: clamp(36px, 5vw, 64px) clamp(24px, 5vw, 72px) !important;
+  overflow: hidden;
+}
+.cta-banner--leadmagnet .container { padding-left: 0; padding-right: 0; }
+.cta-banner__inner {
+  width: 100%;
+  max-width: none;
+  gap: clamp(28px, 5vw, 64px) !important;
+}
+.cta-banner__heading {
+  max-width: 16ch;
+  color: #fff !important;
+}
+.cta-banner__sub { max-width: 42rem; color: rgba(255,255,255,0.9) !important; }
+.cta-banner__input {
+  background: #fff !important;
+  color: var(--color-text-primary, #282724) !important;
+  border-color: rgba(255,255,255,0.76) !important;
+}
+.cta-banner__input::placeholder { color: var(--color-text-muted, #6f6b63) !important; }
+.cta-banner__fine { color: rgba(255,255,255,0.72) !important; }
+@media (max-width: 768px) {
+  .cta-banner--leadmagnet {
+    border-radius: 18px;
+    padding: 28px 20px !important;
+  }
+  .cta-banner__heading { max-width: 100%; }
+}


### PR DESCRIPTION
## Summary
- Adds an actual search drawer/form for the nav search icon.
- Hard-disables the fragile Blog/category hover submenu in CSS.
- Fixes lead magnet/newsletter CTA padding, dead space, input contrast, and responsive spacing.
- Bumps RR_VERSION to 2.0.6 for cache invalidation.

## Release evidence
- Acceptance criteria / expected outcome: CTA/newsletter padding no longer broken, search icon opens visible usable search UI, Blog hover does not dump category links, no horizontal overflow.
- Staging URLs: /blog/, /start-here/, /gear/, /full-time-rv-insurance/.
- Changed pages/components/scripts: header.php, assets/js/main.js, style.css, functions.php.
- Visual QA: PASS by Cian via screenshots for blog CTA, Start Here CTA, search drawer, mobile Start Here.
- Functional QA: PASS by Cian via Playwright: CSS/style version 2.0.6 loaded; searchHidden=false and searchInputVisible=true after search click; Blog hover submenuCount=0/submenuVisible=0; desktop/mobile docScroll equals viewport.
- Branch freshness: branched from origin/main after PR #48.
- Rollback: revert PR #49 or redeploy main SHA b75eae4 if needed.

Refs MJM-282
