### PR TITLE
fix(MJM-283): tighten visual rhythm and mobile post spacing

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -6,7 +6,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'RR_VERSION', '2.0.6' );
+define( 'RR_VERSION', '2.0.7' );
 define( 'RR_THEME_DIR', get_template_directory() );
 define( 'RR_THEME_URI', get_template_directory_uri() );
 

--- a/style.css
+++ b/style.css
@@ -404,3 +404,68 @@ h4[id] {
   }
   .cta-banner__heading { max-width: 100%; }
 }
+
+
+/* MJM-283: overnight visual rhythm cleanup from Aoife QA pass 1. */
+/* Start Here: tighten hero/CTA rhythm and keep sections from feeling floaty. */
+.start-here-hero {
+  padding-top: clamp(3.5rem, 6vw, 5.5rem) !important;
+  padding-bottom: clamp(2.75rem, 5vw, 4rem) !important;
+}
+.start-here-hero h1 {
+  font-size: clamp(2.75rem, 6.8vw, 5.75rem) !important;
+  line-height: 0.98 !important;
+}
+.start-here-hero__dek { max-width: 44rem; }
+.start-here-trust { transform: none !important; margin: 0 !important; padding: 28px 0 0; background: var(--color-cream, #f9f6f0); }
+.start-here-roadmap,
+.start-here-pathways,
+.start-here-featured { padding: clamp(2.5rem, 5vw, 4.5rem) 0 !important; }
+.start-here-page .cta-banner--leadmagnet { margin-top: clamp(2rem, 4vw, 3.5rem); margin-bottom: clamp(2rem, 4vw, 3.5rem); }
+
+/* Blog: reduce empty above-fold space and make mobile filters less chunky. */
+.blog-index { padding-top: clamp(2.5rem, 5vw, 4rem) !important; }
+.blog-index .section-header { margin-bottom: var(--space-8) !important; }
+.blog-discovery { margin-bottom: var(--space-8) !important; }
+@media (max-width: 760px) {
+  .blog-index { padding-top: var(--space-8) !important; }
+  .blog-discovery { padding: var(--space-4) !important; }
+  .category-filter {
+    width: auto !important;
+    min-height: 36px !important;
+    padding: 6px 12px !important;
+    font-size: 11px !important;
+    border-radius: 999px !important;
+  }
+  .blog-category-nav { gap: 8px !important; }
+}
+
+/* Post mobile: prevent title/content from kissing viewport and de-crowd meta/share/trust. */
+@media (max-width: 760px) {
+  .post-header,
+  .post-body,
+  .container--narrow { padding-left: 20px !important; padding-right: 20px !important; }
+  .post-title,
+  .post-header__title,
+  .single-post h1 {
+    font-size: clamp(34px, 10vw, 46px) !important;
+    line-height: 1.06 !important;
+    overflow-wrap: anywhere;
+  }
+  .post-meta,
+  .post-header__meta,
+  .share-row,
+  .post-share { gap: 10px !important; flex-wrap: wrap !important; }
+  .post-trust-panel,
+  .post-sources-panel { padding: var(--space-4) !important; margin-bottom: var(--space-6) !important; }
+}
+
+/* Gear/newsletter/footer rhythm and mobile card breathing room. */
+.gear-page .cta-banner--leadmagnet,
+.page-template-page-gear .cta-banner--leadmagnet { margin-bottom: clamp(2.5rem, 5vw, 4rem) !important; }
+@media (max-width: 640px) {
+  .gear-grid,
+  .posts-grid { padding-left: 4px; padding-right: 4px; }
+  .gear-product-card,
+  .post-card { border-radius: var(--radius-xl); }
+}


### PR DESCRIPTION
## Summary
- Tightens Start Here hero/trust/CTA spacing and mobile rhythm.
- Reduces blog above-fold whitespace and makes mobile filter chips less chunky.
- Adds mobile post side padding/title safeguards and de-crowds post panels.
- Adds footer/CTA breathing room and mobile card padding.
- Bumps RR_VERSION to 2.0.7.

## Release evidence
- Acceptance criteria / expected outcome: address Aoife pass-1 visual rhythm findings; no horizontal overflow; post mobile title not clipped; CTA/footer spacing no longer blocking.
- Staging URLs: /start-here/, /blog/, /full-time-rv-insurance/, /gear/.
- Changed pages/components/scripts: style.css, functions.php.
- Visual QA: PASS by Cian screenshots for Start Here desktop/mobile, Blog mobile, Post mobile, Gear CTA.
- Functional QA: PASS by Cian Playwright: CSS/style version 2.0.7 loaded; tested desktop/mobile docScroll equals viewport.
- Branch freshness: branched from origin/main after PR #49.
- Rollback: revert PR #50 or redeploy main SHA 17b6722 if needed.

Refs MJM-283
