### PR TITLE
fix(MJM-284): repair newsletter submit and cache version

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -273,7 +273,7 @@
     forms.forEach(function (form) {
       form.addEventListener('submit', function (e) {
         // Only show success UI if it's a demo (no real action set)
-        const action = this.getAttribute('action');
+        const action = form.getAttribute('action');
         if (!action || action === '/subscribe') {
           e.preventDefault();
           const successMsg = document.createElement('p');

--- a/functions.php
+++ b/functions.php
@@ -6,7 +6,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'RR_VERSION', '2.0.7' );
+define( 'RR_VERSION', '2.0.8' );
 define( 'RR_THEME_DIR', get_template_directory() );
 define( 'RR_THEME_URI', get_template_directory_uri() );
 
@@ -798,7 +798,7 @@ function rr_newsletter_js() {
                     if (btn) { btn.disabled = false; btn.textContent = orig; }
                 }
 
-                fetch(form.action, {
+                fetch(form.getAttribute('action') || window.location.href, {
                     method: 'POST',
                     credentials: 'same-origin',
                     body: data


### PR DESCRIPTION
## Summary
- Fixes newsletter AJAX submit using `form.getAttribute('action')` so hidden input `name=action` no longer shadows `form.action`.
- Keeps main.js demo handler on `getAttribute` for consistency.
- Bumps RR_VERSION to 2.0.8 so browsers refresh JS/CSS after overnight fixes.

## Release evidence
- Acceptance criteria / expected outcome: newsletter form must not post to `/[object HTMLInputElement]`; Gear must render Amazon affiliate CTAs in browser.
- Staging URLs: /blog/ and /gear/.
- Changed pages/components/scripts: functions.php, assets/js/main.js.
- Functional QA: PASS by Cian via Playwright: newsletter submit POST requested `https://rollingreno.flywheelstaging.com/wp-admin/admin-ajax.php`; no `[object HTMLInputElement]` in HTML/request; CSS/style version 2.0.8 loaded; Gear browser render has 24 Amazon links with `tag=rollingreno-20`, 0 `Product link coming soon`, docScroll=viewport.
- Visual QA: PASS by Cian screenshots for newsletter submit state and Gear products view; no severe visual regression.
- Branch freshness: rebased on main after PR #50.
- Rollback: revert PR #51 or redeploy main SHA 49c2736 if needed.

Refs MJM-284
