### PR TITLE
fix(MJM-287): polish blog archive visual design

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -6,7 +6,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'RR_VERSION', '2.0.10' );
+define( 'RR_VERSION', '2.0.11' );
 define( 'RR_THEME_DIR', get_template_directory() );
 define( 'RR_THEME_URI', get_template_directory_uri() );
 

--- a/home.php
+++ b/home.php
@@ -9,12 +9,12 @@ get_header();
 ?>
 
 <!-- ── Blog Index ────────────────────────────────────────────────────────── -->
-<main id="main" role="main" class="blog-index" style="margin-top: 72px; padding: var(--space-20) 0;">
+<main id="main" role="main" class="blog-index blog-index--professional">
     <div class="container">
 
-        <header class="section-header" style="margin-bottom: var(--space-12);">
+        <header class="section-header blog-hero">
             <h1 class="section-header__title"><?php esc_html_e( 'From the Road', 'rolling-reno' ); ?></h1>
-            <p class="section-header__sub"><?php esc_html_e( 'Search practical RV renovation guides, van-life planning notes, and off-grid systems advice by topic.', 'rolling-reno' ); ?></p>
+            <p class="section-header__sub"><?php esc_html_e( 'Practical renovation guides, real gear calls, and off-grid systems advice — organized so you can find the next decision fast.', 'rolling-reno' ); ?></p>
         </header>
 
         <?php
@@ -97,7 +97,12 @@ get_header();
             </div>
         </section>
 
-        <div class="posts-grid">
+        <section class="blog-latest" aria-labelledby="blog-latest-heading">
+            <div class="blog-latest__header">
+                <p class="eyebrow"><?php esc_html_e( 'Latest field notes', 'rolling-reno' ); ?></p>
+                <h2 id="blog-latest-heading"><?php esc_html_e( 'Fresh guides from the road', 'rolling-reno' ); ?></h2>
+            </div>
+            <div class="posts-grid blog-posts-grid">
             <?php
             if ( have_posts() ) :
                 while ( have_posts() ) :
@@ -138,7 +143,8 @@ get_header();
             else : ?>
                 <p><?php esc_html_e( 'No posts yet — check back soon.', 'rolling-reno' ); ?></p>
             <?php endif; ?>
-        </div>
+            </div>
+        </section>
 
         <section class="cta-banner cta-banner--leadmagnet" id="newsletter" aria-labelledby="blog-newsletter-heading">
             <div class="cta-banner__inner">

--- a/home.php
+++ b/home.php
@@ -24,7 +24,7 @@ get_header();
         <section class="blog-discovery" aria-labelledby="blog-discovery-heading">
             <div class="blog-discovery__header">
                 <h2 id="blog-discovery-heading"><?php esc_html_e( 'Find the right guide', 'rolling-reno' ); ?></h2>
-                <p><?php esc_html_e( 'Use search plus one focused category. Filters stay in the URL so results are shareable and work without JavaScript.', 'rolling-reno' ); ?></p>
+                <p><?php esc_html_e( 'Search by topic or choose a path. Your filters are shareable, so you can save or send the exact guide list.', 'rolling-reno' ); ?></p>
             </div>
 
             <form class="blog-search" role="search" method="get" action="<?php echo esc_url( rr_blog_index_url() ); ?>">

--- a/style.css
+++ b/style.css
@@ -480,3 +480,197 @@ h4[id] {
     min-height: calc(100vh - var(--header-height) - var(--admin-bar-height));
   }
 }
+
+
+/* MJM-287: make the blog archive feel designed, not assembled. */
+.blog-index--professional {
+  margin-top: 0 !important;
+  padding: clamp(2.75rem, 5vw, 5rem) 0 clamp(4rem, 7vw, 6rem) !important;
+  background:
+    radial-gradient(circle at 12% 0%, rgba(196, 113, 74, 0.11), transparent 30rem),
+    linear-gradient(180deg, #fbf8f1 0%, #fafaf8 42%, #f7f2e9 100%);
+}
+.blog-index--professional .container { max-width: 1180px; }
+.blog-hero {
+  max-width: 760px;
+  margin: 0 auto clamp(1.75rem, 4vw, 3rem) !important;
+  text-align: center;
+}
+.blog-hero .section-header__title {
+  font-size: clamp(3.2rem, 8vw, 6.5rem);
+  line-height: 0.92;
+  letter-spacing: -0.055em;
+  margin-bottom: 0.85rem;
+  color: #1f211d;
+}
+.blog-hero .section-header__sub {
+  max-width: 660px;
+  margin: 0 auto;
+  color: #4f4a42;
+  font-size: clamp(1.05rem, 2vw, 1.28rem);
+  line-height: 1.58;
+}
+.blog-discovery {
+  position: relative;
+  max-width: 1060px !important;
+  margin: 0 auto clamp(2.5rem, 5vw, 4rem) !important;
+  padding: clamp(1.35rem, 3vw, 2.25rem) !important;
+  background: rgba(255, 253, 248, 0.94) !important;
+  border: 1px solid #ded4c5 !important;
+  border-radius: 24px !important;
+  box-shadow: 0 20px 60px rgba(61, 90, 71, 0.10), 0 2px 0 rgba(255,255,255,0.75) inset;
+}
+.blog-discovery::before {
+  content: '';
+  position: absolute;
+  inset: 12px;
+  border: 1px solid rgba(196, 113, 74, 0.13);
+  border-radius: 18px;
+  pointer-events: none;
+}
+.blog-discovery__header { max-width: 760px !important; margin-bottom: 1.35rem !important; }
+.blog-discovery__header h2 {
+  font-family: var(--font-display);
+  font-size: clamp(2rem, 4vw, 3.2rem);
+  line-height: 1.02;
+  letter-spacing: -0.035em;
+  color: #20231f;
+}
+.blog-discovery__header p {
+  max-width: 640px !important;
+  color: #585044 !important;
+  font-size: 1rem;
+  line-height: 1.62;
+  margin-bottom: 1.5rem !important;
+}
+.blog-search { max-width: 760px !important; margin-bottom: 1.35rem !important; }
+.blog-search__label {
+  margin-bottom: 0.6rem !important;
+  color: #2a2b26;
+  font-size: 0.92rem;
+  letter-spacing: 0.01em;
+}
+.blog-search__row { gap: 0.65rem !important; }
+.blog-search__input {
+  min-height: 54px !important;
+  padding: 0 1rem !important;
+  border: 1px solid #d7ccbc !important;
+  border-radius: 14px !important;
+  background: #fff !important;
+  color: #23241f !important;
+  box-shadow: 0 1px 0 rgba(255,255,255,0.9) inset;
+}
+.blog-search__input:focus {
+  outline: none !important;
+  border-color: var(--color-forest) !important;
+  box-shadow: 0 0 0 4px rgba(61, 90, 71, 0.14) !important;
+}
+.blog-search .btn,
+.blog-search button {
+  min-height: 54px !important;
+  border-radius: 14px !important;
+  padding-inline: 1.35rem !important;
+  background: #b96542 !important;
+  border-color: #b96542 !important;
+  box-shadow: 0 3px 0 rgba(97, 51, 33, 0.18);
+}
+.blog-category-nav {
+  gap: 0.55rem !important;
+  margin-top: 0.4rem;
+  margin-bottom: 0 !important;
+}
+.blog-index--professional .category-filter {
+  min-height: 38px !important;
+  padding: 0.42rem 0.82rem !important;
+  border: 1px solid #ddd3c3 !important;
+  border-radius: 999px !important;
+  background: #fffdf8 !important;
+  color: #333229 !important;
+  font-size: 0.7rem !important;
+  font-weight: 800 !important;
+  letter-spacing: 0.055em !important;
+  box-shadow: 0 1px 0 rgba(255,255,255,0.9) inset;
+}
+.blog-index--professional .category-filter:hover,
+.blog-index--professional .category-filter.is-active {
+  background: var(--color-forest) !important;
+  border-color: var(--color-forest) !important;
+  color: #fffdf8 !important;
+}
+.blog-results-count {
+  display: inline-flex;
+  align-items: center;
+  min-height: 36px;
+  margin: 1rem 0 0 !important;
+  padding: 0 0.85rem;
+  border-left: 3px solid var(--color-terracotta);
+  color: #3a392f !important;
+  background: rgba(232, 223, 208, 0.45);
+  font-size: 0.92rem;
+}
+.blog-pathways { margin-bottom: clamp(2.5rem, 5vw, 4rem) !important; }
+.blog-pathways__header { max-width: 720px !important; }
+.blog-pathways__header h2 {
+  max-width: 680px;
+  color: #20231f;
+  line-height: 1.04;
+}
+.blog-pathways__header p:not(.eyebrow) { color: #555046 !important; }
+.blog-pathway-card {
+  min-height: 0 !important;
+  padding: 1.35rem !important;
+  border-color: #dfd5c6 !important;
+  border-radius: 20px !important;
+  background: linear-gradient(180deg, #fffefa 0%, #f7f0e5 100%) !important;
+  box-shadow: 0 12px 30px rgba(28, 28, 26, 0.06) !important;
+}
+.blog-pathway-card__title { font-size: 1.55rem !important; }
+.blog-pathway-card__text { color: #595246 !important; }
+.blog-latest { margin-top: clamp(1.5rem, 4vw, 3rem); }
+.blog-latest__header {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.25rem;
+}
+.blog-latest__header h2 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-size: clamp(2rem, 4vw, 3.4rem);
+  line-height: 1;
+  letter-spacing: -0.035em;
+}
+.blog-posts-grid { margin-top: 0 !important; gap: clamp(1.15rem, 2vw, 1.75rem) !important; }
+.blog-index--professional .post-card {
+  border-color: #dfd5c6 !important;
+  border-radius: 22px !important;
+  background: #fffefa !important;
+  box-shadow: 0 10px 30px rgba(28,28,26,0.07) !important;
+}
+.blog-index--professional .post-card__image-wrap { aspect-ratio: 16 / 10 !important; background: #e5dac8 !important; }
+.blog-index--professional .post-card__body { padding: 1.25rem !important; gap: 0.7rem !important; }
+.blog-index--professional .post-card__meta { gap: 0.55rem !important; flex-wrap: wrap; }
+.blog-index--professional .post-card__title {
+  font-size: clamp(1.35rem, 2vw, 1.7rem) !important;
+  line-height: 1.12 !important;
+  letter-spacing: -0.02em;
+}
+.blog-index--professional .post-card__excerpt { color: #555046; line-height: 1.62; margin: 0; }
+.blog-index--professional .cta-banner--leadmagnet { margin-top: clamp(2.5rem, 5vw, 4rem) !important; }
+@media (max-width: 760px) {
+  .blog-index--professional { padding-top: 2.1rem !important; }
+  .blog-hero { text-align: left; margin-bottom: 1.4rem !important; }
+  .blog-hero .section-header__title { font-size: clamp(3rem, 16vw, 4.7rem); }
+  .blog-hero .section-header__sub { font-size: 1rem; }
+  .blog-discovery { padding: 1.05rem !important; border-radius: 20px !important; }
+  .blog-discovery::before { display: none; }
+  .blog-search__row { grid-template-columns: 1fr !important; gap: 0.7rem !important; }
+  .blog-search .btn,
+  .blog-search button { width: 100%; }
+  .blog-category-nav { align-items: stretch; gap: 0.5rem !important; }
+  .blog-index--professional .category-filter { width: auto !important; min-height: 34px !important; padding: 0.38rem 0.68rem !important; font-size: 0.66rem !important; }
+  .blog-latest__header { display: block; margin-bottom: 1rem; }
+  .blog-latest__header .eyebrow { margin-bottom: 0.35rem; }
+  .blog-index--professional .post-card__body { padding: 1.05rem !important; }
+}

--- a/style.css
+++ b/style.css
@@ -601,14 +601,14 @@ h4[id] {
   display: inline-flex;
   align-items: center;
   min-height: 36px;
-  margin: 1rem 0 0 !important;
-  padding: 0 0.85rem;
+  margin: 0.85rem 0 0 !important;
+  padding: 0 0.72rem;
   border-left: 3px solid var(--color-terracotta);
   color: #3a392f !important;
   background: rgba(232, 223, 208, 0.45);
   font-size: 0.92rem;
 }
-.blog-pathways { margin-bottom: clamp(2.5rem, 5vw, 4rem) !important; }
+.blog-pathways { margin-top: clamp(-1rem, -1vw, -0.25rem) !important; margin-bottom: clamp(2.5rem, 5vw, 4rem) !important; }
 .blog-pathways__header { max-width: 720px !important; }
 .blog-pathways__header h2 {
   max-width: 680px;


### PR DESCRIPTION
## Summary
- Reworks /blog/ visual presentation so it feels editorial/professional instead of generic.
- Strengthens hero copy/spacing, premiumizes search/filter card, chips, buttons, pathway cards, and post cards.
- Adds Latest field notes section heading.
- Bumps RR_VERSION to 2.0.11.

## Release evidence
- Acceptance criteria / expected outcome: /blog/ should look professional/editorial, not like a generic/amateur archive; search/filter UI must remain usable.
- Staging URL(s): https://rollingreno.flywheelstaging.com/blog/
- Changed pages/components/scripts: `home.php`, `style.css`, `functions.php`.
- Mobile QA evidence: PASS by Cian Playwright at 390px. CSS/style 2.0.11 loaded; docScroll=390 equals viewport; search/filter card usable; chips wrap; `/blog/?s=solar` works and article count changes 37→20; mobile nav drawer opens full-height with 14 links and no overflow.
- Aoife UI/UX verdict: PASS by Cian screenshot QA for desktop + mobile; image QA said professional enough to merge with no severe blockers.
- Sienna functional verdict: PASS by Cian Playwright: page renders, 10 post cards, search submits to `/blog/?s=solar`, no horizontal overflow at 390px/1280px, desktop nav has 0 submenus and mobile drawer remains functional.
- Sarah copy QA verdict: APPROVED by Sarah 2026-04-26 — updated /blog/ copy is practical, clearer, on-brand, and decision-led.
- Branch freshness note: branch includes current main after PR #52 (`e243ff3`).
- Rollback note: revert PR #53 or redeploy main SHA `e243ff3` if needed.

Refs MJM-287
