### PR TITLE
fix(MJM-290): deploy staging from main

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -3,7 +3,7 @@ name: Deploy to Flywheel Staging
 on:
   push:
     branches:
-      - staging
+      - main
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Closes MJM-290

Root cause: staging deploy workflow only auto-ran for pushes to `staging`, while recent successful staging deploys were manual runs from feature branches. After PRs merged, `main` advanced without a staging deploy, letting staging drift.

Change:
- Deploy staging automatically on every push to `main`.
- Keep `workflow_dispatch` for explicit emergency/manual redeploys.

Immediate mitigation already completed:
- Manually redeployed staging from `main` commit `dd4fdfe` via run https://github.com/MJM-Agents/rolling-reno-theme/actions/runs/24972592762 (success).

QA / release evidence:
- Workflow syntax change only.
- Manual staging deploy from `main` succeeded before this PR.
- Rollback: revert this one-line trigger change.