### PR TITLE
test(MJM-289): add Rolling Reno regression suite

### DIFF
--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -1,0 +1,32 @@
+name: Regression Tests
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  rolling-reno-regression:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+      - run: npm ci
+      - run: npx playwright install --with-deps chromium
+      - name: Run Playwright regression tests against staging
+        env:
+          ROLLING_RENO_BASE_URL: https://rollingreno.flywheelstaging.com
+          STAGING_PRIVACY_USER: ${{ secrets.STAGING_PRIVACY_USER }}
+          STAGING_PRIVACY_PASS: ${{ secrets.STAGING_PRIVACY_PASS }}
+        run: npm run test:regression
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report
+          path: |
+            playwright-report/
+            test-results/
+          if-no-files-found: ignore

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,78 @@
+{
+  "name": "rolling-reno-theme",
+  "version": "2.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "rolling-reno-theme",
+      "version": "2.0.0",
+      "devDependencies": {
+        "@playwright/test": "^1.59.1"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "rolling-reno-theme",
+  "private": true,
+  "version": "2.0.0",
+  "description": "Rolling Reno WordPress theme regression tests",
+  "scripts": {
+    "test:e2e": "playwright test",
+    "test:e2e:headed": "playwright test --headed",
+    "test:regression": "playwright test tests/e2e/regression.spec.ts",
+    "test:install": "playwright install chromium"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.59.1"
+  }
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const baseURL = process.env.ROLLING_RENO_BASE_URL || 'https://rollingreno.flywheelstaging.com';
+const httpCredentials = process.env.STAGING_PRIVACY_USER && process.env.STAGING_PRIVACY_PASS
+  ? { username: process.env.STAGING_PRIVACY_USER, password: process.env.STAGING_PRIVACY_PASS }
+  : { username: 'rollingreno', password: 'Privy123' };
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  timeout: 45_000,
+  expect: { timeout: 8_000 },
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? [['github'], ['html', { open: 'never' }], ['list']] : [['list']],
+  use: {
+    baseURL,
+    httpCredentials,
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    {
+      name: 'desktop-chromium',
+      use: { ...devices['Desktop Chrome'], viewport: { width: 1280, height: 900 } },
+    },
+    {
+      name: 'mobile-chromium',
+      use: { ...devices['Pixel 5'], viewport: { width: 390, height: 844 } },
+    },
+  ],
+});

--- a/style.css
+++ b/style.css
@@ -674,3 +674,20 @@ h4[id] {
   .blog-latest__header .eyebrow { margin-bottom: 0.35rem; }
   .blog-index--professional .post-card__body { padding: 1.05rem !important; }
 }
+
+/* MJM-289: mobile regression-test hardening.
+   Keep iOS from zooming search inputs and preserve the viewport width after search/menu interactions. */
+@media (max-width: 768px) {
+  .site-search__input,
+  .blog-search__input {
+    font-size: 16px !important;
+  }
+  .site-search,
+  .mobile-menu,
+  .blog-discovery,
+  .blog-search,
+  .blog-search__row {
+    box-sizing: border-box;
+    max-width: 100vw;
+  }
+}

--- a/tests/e2e/regression.spec.ts
+++ b/tests/e2e/regression.spec.ts
@@ -1,0 +1,130 @@
+import { expect, type Locator, test } from '@playwright/test';
+
+async function viewportMetrics(page) {
+  return page.evaluate(() => ({
+    scrollWidth: document.documentElement.scrollWidth,
+    clientWidth: document.documentElement.clientWidth,
+    bodyScrollWidth: document.body.scrollWidth,
+    bodyClientWidth: document.body.clientWidth,
+    viewportWidth: window.innerWidth,
+  }));
+}
+
+async function expectNoHorizontalOverflow(page) {
+  const metrics = await viewportMetrics(page);
+  expect(metrics.scrollWidth, JSON.stringify(metrics)).toBeLessThanOrEqual(metrics.clientWidth);
+  expect(metrics.bodyScrollWidth, JSON.stringify(metrics)).toBeLessThanOrEqual(metrics.bodyClientWidth + 1);
+}
+
+async function expectInsideViewport(locator: Locator, viewportWidth: number, label: string) {
+  await expect(locator, label).toBeVisible();
+  const box = await locator.boundingBox();
+  expect(box, `${label} bounding box`).not.toBeNull();
+  expect(box!.x, `${label} left edge`).toBeGreaterThanOrEqual(-1);
+  expect(box!.x + box!.width, `${label} right edge`).toBeLessThanOrEqual(viewportWidth + 1);
+}
+
+test.describe('Rolling Reno regression guardrails', () => {
+  test('mobile homepage loads closed, with no blank search/menu band and unclipped hero', async ({ page, isMobile }) => {
+    test.skip(!isMobile, 'mobile-only regression from iOS screenshot');
+
+    await page.goto('/');
+    await expect(page.locator('#site-search')).toHaveAttribute('aria-hidden', 'true');
+    await expect(page.locator('#mobile-menu')).toHaveAttribute('aria-hidden', 'true');
+    await expect(page.locator('.site-nav__hamburger')).toHaveAttribute('aria-expanded', 'false');
+    await expect(page.locator('.site-nav__search-btn').first()).toHaveAttribute('aria-expanded', 'false');
+    await expectNoHorizontalOverflow(page);
+
+    const hero = page.locator('.hero').first();
+    const heroContent = page.locator('.hero__content').first();
+    const heroTitle = page.locator('.hero__title').first();
+    await expectInsideViewport(heroContent, 390, 'mobile hero content card');
+    await expectInsideViewport(heroTitle, 390, 'mobile hero title');
+
+    const navBox = await page.locator('#site-nav').boundingBox();
+    const heroBox = await hero.boundingBox();
+    expect(navBox).not.toBeNull();
+    expect(heroBox).not.toBeNull();
+    const gap = heroBox!.y - (navBox!.y + navBox!.height);
+    expect(gap, 'no unexplained blank band between header and hero').toBeLessThanOrEqual(8);
+  });
+
+  test('mobile search opens with a visible input and closes without leaving a blank band', async ({ page, isMobile }) => {
+    test.skip(!isMobile, 'mobile-only search regression');
+
+    await page.goto('/');
+    await page.locator('.site-nav__search-btn').first().click();
+    await expect(page.locator('#site-search')).toHaveAttribute('aria-hidden', 'false');
+    await expect(page.locator('#site-search-input')).toBeVisible();
+    await expect(page.locator('.site-search__submit')).toBeVisible();
+    await expect(page.locator('.site-search__close')).toBeVisible();
+    await expectNoHorizontalOverflow(page);
+
+    await page.locator('.site-search__close').click();
+    await expect(page.locator('#site-search')).toHaveAttribute('aria-hidden', 'true');
+    await expect(page.locator('.site-nav__search-btn').first()).toHaveAttribute('aria-expanded', 'false');
+    await expectNoHorizontalOverflow(page);
+  });
+
+  test('mobile nav drawer opens as a full usable drawer and closes via Escape/link', async ({ page, isMobile }) => {
+    test.skip(!isMobile, 'mobile-only nav regression');
+
+    await page.goto('/blog/');
+    await page.locator('.site-nav__hamburger').click();
+    await expect(page.locator('#mobile-menu')).toHaveAttribute('aria-hidden', 'false');
+    await expect(page.locator('#mobile-menu a')).toHaveCount(14);
+    const box = await page.locator('#mobile-menu').boundingBox();
+    expect(box).not.toBeNull();
+    expect(box!.width).toBeGreaterThanOrEqual(389);
+    expect(box!.height).toBeGreaterThan(600);
+    await expectNoHorizontalOverflow(page);
+
+    await page.keyboard.press('Escape');
+    await expect(page.locator('#mobile-menu')).toHaveAttribute('aria-hidden', 'true');
+
+    await page.locator('.site-nav__hamburger').click();
+    await page.locator('#mobile-menu a', { hasText: 'Start Here' }).first().click();
+    await expect(page).toHaveURL(/\/start-here\/?/);
+    await expect(page.locator('#mobile-menu')).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  test('desktop blog hover does not expose the retired submenu', async ({ page, isMobile }) => {
+    test.skip(isMobile, 'desktop-only submenu regression');
+
+    await page.goto('/blog/');
+    await page.locator('.site-nav__link', { hasText: 'Blog' }).hover();
+    await page.waitForTimeout(150);
+    await expect(page.locator('.site-nav__submenu')).toHaveCount(0);
+    await expectNoHorizontalOverflow(page);
+  });
+
+  test('blog search/filter UI remains usable and shareable', async ({ page }) => {
+    await page.goto('/blog/');
+    await expect(page.locator('.blog-discovery')).toBeVisible();
+    await expect(page.locator('.category-filter')).toHaveCount(7);
+    await page.locator('#blog-search-input').fill('solar');
+    await page.locator('.blog-search button[type="submit"], .blog-search button').click();
+    await expect(page).toHaveURL(/\/blog\/\?s=solar/);
+    await page.waitForLoadState('networkidle');
+    await expect(page.locator('.blog-results-count')).toContainText(/article/);
+    await expectNoHorizontalOverflow(page);
+  });
+
+  test('gear page keeps affiliate CTAs and never shows placeholders', async ({ page }) => {
+    await page.goto('/gear/');
+    await expect(page.locator('body')).not.toContainText('Product link coming soon');
+    const amazonLinks = page.locator('a[href*="amazon.com"][href*="tag=rollingreno-20"]');
+    await expect(amazonLinks.first()).toBeVisible();
+    expect(await amazonLinks.count()).toBeGreaterThanOrEqual(12);
+    await expectNoHorizontalOverflow(page);
+  });
+
+  test('core public pages render without 404 signals or overflow', async ({ page }) => {
+    for (const path of ['/', '/blog/', '/start-here/', '/gear/', '/full-time-rv-insurance/']) {
+      await page.goto(path);
+      await expect(page.locator('body')).not.toContainText('Page not found');
+      await expect(page.locator('body')).not.toContainText('Nothing found');
+      await expectNoHorizontalOverflow(page);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Adds Playwright regression test setup for Rolling Reno.
- Covers mobile nav/search overlay state, hero clipping/overflow, retired desktop submenu, blog search/filter behavior, gear affiliate link regressions, and core public pages.
- Adds GitHub Actions workflow to run regression tests against staging on PRs.
- Adds mobile CSS hardening for iOS search input zoom / viewport width stability.

## TDD evidence
- First local regression run exposed mobile `/blog/?s=solar` horizontal overflow / flaky viewport expansion.
- Added wait + mobile input/viewport hardening, then reran suite green.

## Verification
- `php -l functions.php` ✅
- `php -l header.php` ✅
- `php -l home.php` ✅
- `npm run test:regression` ✅ — 10 passed / 4 skipped locally
- GitHub Actions `rolling-reno-regression` ✅ — 10 passed / 4 skipped

## Release QA evidence
- Acceptance criteria: add a repeatable CI regression suite covering mobile nav/search overlay state, hero overflow/clipping, retired desktop submenu behavior, blog search/filter behavior, gear affiliate links, and core public pages.
- Expected outcome: PRs against Rolling Reno run Playwright regression checks against staging and block obvious mobile/search/blog/affiliate regressions before merge.
- Staging URL: https://rollingreno.flywheelstaging.com
- Changed pages/components/scripts: `.github/workflows/regression-tests.yml`, `tests/e2e/regression.spec.ts`, `playwright.config.ts`, `package.json`, `package-lock.json`, and defensive mobile search CSS in `style.css`.
- Mobile QA evidence: Playwright mobile viewport coverage passed locally and in CI; local `npm run test:regression` passed 10/10 runnable checks with 4 dependency-skipped checks; assertions include mobile search overlay visibility, no horizontal overflow, hamburger/menu state, hero clipping, and blog search behavior.
- Aoife UI/UX verdict: N/A for visual sign-off because this is regression infrastructure plus defensive mobile CSS; visual/layout regression assertions are included in Playwright coverage.
- Sienna functional verdict: Playwright regression suite green locally and in GitHub Actions.
- Sarah copy QA verdict: N/A — no copy/content changed.
- Branch freshness/rebase note: branch rebased/updated against current `origin/main` at `e53ba5f` on 2026-04-27 after resume.
- Rollback note: revert this PR to remove the regression workflow/test suite and the defensive mobile CSS hardening.

## Resume note
- Global pause was removed after Mike authorized resuming work on 2026-04-27 09:19 ET. Reviewer lane has been restarted.


