### PR TITLE
fix(MJM-265): align blog archive metadata with Yoast

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -350,39 +350,89 @@ function rr_category_hub_config_for_slug( $slug ) {
     return $config[ $slug ] ?? array();
 }
 
-function rr_category_hub_document_title( $title ) {
+function rr_category_hub_current_config() {
     if ( ! is_category() ) {
-        return $title;
+        return array();
     }
+
     $term = get_queried_object();
     if ( ! $term || empty( $term->slug ) ) {
-        return $title;
+        return array();
     }
-    $config = rr_category_hub_config_for_slug( $term->slug );
+
+    return rr_category_hub_config_for_slug( $term->slug );
+}
+
+function rr_category_hub_document_title( $title ) {
+    $config = rr_category_hub_current_config();
     if ( empty( $config['seo_title'] ) ) {
         return $title;
     }
+
     $title['title'] = $config['seo_title'];
     $title['site']  = get_bloginfo( 'name' );
     return $title;
 }
 add_filter( 'document_title_parts', 'rr_category_hub_document_title' );
 
+function rr_category_hub_wpseo_title( $title ) {
+    $config = rr_category_hub_current_config();
+    if ( empty( $config['seo_title'] ) ) {
+        return $title;
+    }
+
+    return $config['seo_title'] . ' - ' . get_bloginfo( 'name' );
+}
+add_filter( 'wpseo_title', 'rr_category_hub_wpseo_title', 20 );
+add_filter( 'wpseo_opengraph_title', 'rr_category_hub_wpseo_title', 20 );
+add_filter( 'wpseo_twitter_title', 'rr_category_hub_wpseo_title', 20 );
+
+function rr_category_hub_meta_description_value() {
+    $config = rr_category_hub_current_config();
+    return empty( $config['seo_desc'] ) ? '' : $config['seo_desc'];
+}
+
+function rr_category_hub_wpseo_description( $description ) {
+    $hub_description = rr_category_hub_meta_description_value();
+    return $hub_description ? $hub_description : $description;
+}
+add_filter( 'wpseo_metadesc', 'rr_category_hub_wpseo_description', 20 );
+add_filter( 'wpseo_opengraph_desc', 'rr_category_hub_wpseo_description', 20 );
+add_filter( 'wpseo_twitter_description', 'rr_category_hub_wpseo_description', 20 );
+
 function rr_category_hub_meta_description() {
-    if ( ! is_category() ) {
+    if ( defined( 'WPSEO_VERSION' ) ) {
         return;
     }
-    $term = get_queried_object();
-    if ( ! $term || empty( $term->slug ) ) {
+
+    $description = rr_category_hub_meta_description_value();
+    if ( ! $description ) {
         return;
     }
-    $config = rr_category_hub_config_for_slug( $term->slug );
-    if ( empty( $config['seo_desc'] ) ) {
-        return;
-    }
-    echo '<meta name="description" content="' . esc_attr( $config['seo_desc'] ) . '">' . "\n";
+
+    echo '<meta name="description" content="' . esc_attr( $description ) . '">' . "\n";
 }
 add_action( 'wp_head', 'rr_category_hub_meta_description', 2 );
+
+
+function rr_category_hub_wpseo_schema_webpage( $data ) {
+    $config = rr_category_hub_current_config();
+    if ( empty( $config['seo_title'] ) ) {
+        return $data;
+    }
+
+    $title       = $config['seo_title'] . ' - ' . get_bloginfo( 'name' );
+    $description = $config['seo_desc'] ?? '';
+
+    $data['name']     = $title;
+    $data['headline'] = $title;
+    if ( $description ) {
+        $data['description'] = $description;
+    }
+
+    return $data;
+}
+add_filter( 'wpseo_schema_webpage', 'rr_category_hub_wpseo_schema_webpage', 20 );
 
 // ─── Preconnect & Preload (Google Fonts, hero image) ────────────────────────
 
@@ -905,9 +955,17 @@ function rr_blog_hub_cards() {
     );
 }
 
+function rr_blog_archive_seo_title() {
+    return __( 'Rolling Reno Blog: RV Renovation, Van Life & Off-Grid Guides', 'rolling-reno' );
+}
+
+function rr_blog_archive_seo_description() {
+    return __( 'Browse Rolling Reno guides by starting point: RV renovation planning, vehicle choices, off-grid systems, interior layouts, van life, and full-time RV life.', 'rolling-reno' );
+}
+
 function rr_blog_archive_document_title( $title ) {
     if ( is_home() || rr_is_blog_index_request() ) {
-        $title['title'] = __( 'Rolling Reno Blog: RV Renovation, Van Life & Off-Grid Guides', 'rolling-reno' );
+        $title['title'] = rr_blog_archive_seo_title();
         $title['site']  = get_bloginfo( 'name' );
     }
 
@@ -915,14 +973,52 @@ function rr_blog_archive_document_title( $title ) {
 }
 add_filter( 'document_title_parts', 'rr_blog_archive_document_title' );
 
-function rr_blog_archive_meta_description() {
+function rr_blog_archive_wpseo_title( $title ) {
     if ( ! ( is_home() || rr_is_blog_index_request() ) ) {
+        return $title;
+    }
+
+    return rr_blog_archive_seo_title() . ' - ' . get_bloginfo( 'name' );
+}
+add_filter( 'wpseo_title', 'rr_blog_archive_wpseo_title', 20 );
+add_filter( 'wpseo_opengraph_title', 'rr_blog_archive_wpseo_title', 20 );
+add_filter( 'wpseo_twitter_title', 'rr_blog_archive_wpseo_title', 20 );
+
+function rr_blog_archive_wpseo_description( $description ) {
+    if ( ! ( is_home() || rr_is_blog_index_request() ) ) {
+        return $description;
+    }
+
+    return rr_blog_archive_seo_description();
+}
+add_filter( 'wpseo_metadesc', 'rr_blog_archive_wpseo_description', 20 );
+add_filter( 'wpseo_opengraph_desc', 'rr_blog_archive_wpseo_description', 20 );
+add_filter( 'wpseo_twitter_description', 'rr_blog_archive_wpseo_description', 20 );
+
+function rr_blog_archive_meta_description() {
+    if ( defined( 'WPSEO_VERSION' ) || ! ( is_home() || rr_is_blog_index_request() ) ) {
         return;
     }
 
-    echo '<meta name="description" content="' . esc_attr__( 'Browse Rolling Reno guides by starting point: RV renovation planning, vehicle choices, off-grid systems, interior layouts, van life, and full-time RV life.', 'rolling-reno' ) . '">' . "\n";
+    echo '<meta name="description" content="' . esc_attr( rr_blog_archive_seo_description() ) . '">' . "\n";
 }
 add_action( 'wp_head', 'rr_blog_archive_meta_description', 2 );
+
+
+function rr_blog_archive_wpseo_schema_webpage( $data ) {
+    if ( ! ( is_home() || rr_is_blog_index_request() ) ) {
+        return $data;
+    }
+
+    $title = rr_blog_archive_seo_title() . ' - ' . get_bloginfo( 'name' );
+
+    $data['name']        = $title;
+    $data['headline']    = $title;
+    $data['description'] = rr_blog_archive_seo_description();
+
+    return $data;
+}
+add_filter( 'wpseo_schema_webpage', 'rr_blog_archive_wpseo_schema_webpage', 20 );
 
 /**
  * Keep /blog/?category=<slug>&s=<term> crawlable and non-JS friendly.


### PR DESCRIPTION
## Summary
- Assessed `origin/main` after PRs #48-#55 and current staging for MJM-265.
- Most archive/category/page remediation is already present: redesigned `/blog/`, crawlable category hubs, retired desktop submenu, mobile nav/search fixes, and regression suite are live.
- Remaining real gap: Yoast is still overriding archive metadata, so staging shows generic `<title>`/OG/schema names (`Blog - Rolling Reno`, `* Archives - Rolling Reno`) instead of the theme’s remediation SEO titles.
- Added Yoast filters for blog index + category hubs: title, meta description, OpenGraph/Twitter title/description, and schema WebPage name/headline/description. Kept non-Yoast fallback meta descriptions.

## Current staging evidence / gap
- `/blog/`: redesigned UI present; no retired `.site-nav__submenu`; but `<title>Blog - Rolling Reno</title>` and `og:title="Blog - Rolling Reno"`.
- `/category/start-here-planning/`: category hub UI present; but `<title>Start Here & Planning Archives - Rolling Reno</title>` and Yoast schema name uses the same generic Archives title.
- Category hubs verified HTTP 200 with hub UI classes for: `start-here-planning`, `vehicle-guides`, `systems-off-grid`, `interior-build-layouts`, `van-life`, `rv-life`.
- `/category/uncategorized/` redirects/renders `/blog/` as intended.

## Acceptance criteria / expected outcome
- Blog index metadata uses `Rolling Reno Blog: RV Renovation, Van Life & Off-Grid Guides - Rolling Reno` in Yoast-controlled title/OG/Twitter/schema surfaces.
- Category hubs use each configured `seo_title` and `seo_desc` instead of generic WordPress `Archives` metadata.
- Non-Yoast installs keep the existing fallback `<meta name="description">` behavior.
- No layout, navigation, card, excerpt, image, or responsive regressions.

## Staging URL(s)
- Current staging baseline/gap: https://rollingreno.flywheelstaging.com/blog/
- Current staging baseline/gap: https://rollingreno.flywheelstaging.com/category/start-here-planning/
- Note: staging deploy workflow currently deploys from `main`; this PR will need the usual post-merge staging verification after main deploy.

## Changed pages/components/scripts
- `functions.php`
- Affects metadata for `/blog/` and configured `/category/<slug>/` hubs only.

## Validation
- `php -l functions.php` ✅
- `php -l` all root PHP templates ✅
- `git diff --check` ✅
- `npm run test:regression` against staging: 10 passed / 4 skipped ✅
- Manual curl checks for `/blog/`, all configured category hubs, and `/category/uncategorized/` ✅

## QA verdicts
- Mobile QA evidence: `npm run test:regression` covered Pixel 5 / 390px mobile viewport checks for closed mobile search/menu, hamburger drawer, `/blog/` mobile nav behavior, core pages, and no horizontal overflow. Result: 10 passed / 4 skipped.
- Aoife UI/UX verdict: N/A — metadata-only PHP change; no visual layout/CSS/template markup changes.
- Sienna functional verdict: regression suite passed against staging baseline; post-merge metadata smoke check still required after staging deploy.
- Sarah copy QA verdict: Required before merge because `functions.php` controls SEO metadata copy. This PR reuses existing configured SEO strings, but gate should keep merge blocked until Sarah/Cian marks copy approval or explicit N/A.

## Branch freshness
- Branched from `origin/main` at `9b53b30` (PR #55 merge). Fresh after PRs #48-#55.

## Rollback note
- Revert this PR to remove the Yoast filters and return metadata behavior to the current WordPress/Yoast defaults.
