### PR TITLE
MJM-254: Reuse affiliate recommendation cards

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1771,6 +1771,15 @@
 }
 
 /* Image wrapper */
+.affiliate-card__image-link {
+  display: block;
+  flex-shrink: 0;
+  border-radius: var(--radius-md);
+}
+.affiliate-card__image-link:focus-visible {
+  outline: 3px solid var(--color-terracotta);
+  outline-offset: 3px;
+}
 .affiliate-card__image-wrap {
   flex-shrink: 0;
   width: 140px;
@@ -1827,6 +1836,7 @@
 }
 
 /* Footer: stars + CTA */
+.affiliate-card__meta,
 .affiliate-card__footer {
   display: flex;
   flex-wrap: wrap;
@@ -1838,6 +1848,34 @@
   font-size: 16px;
   color: var(--color-terracotta);
   letter-spacing: -0.05em;
+}
+.affiliate-card__price {
+  font-family: var(--font-body);
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--color-text-muted);
+  letter-spacing: 0.05em;
+}
+.affiliate-card__best-for {
+  font-size: var(--text-body-sm);
+  color: var(--color-text-primary);
+  margin: 0 0 var(--space-2);
+}
+.affiliate-card__details {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-4);
+  margin-bottom: var(--space-3);
+  font-size: var(--text-body-sm);
+}
+.affiliate-card__detail-list ul {
+  margin: var(--space-1) 0 0;
+  padding-left: 1.1rem;
+}
+.affiliate-card__detail-list li + li { margin-top: 2px; }
+.affiliate-card__cta--disabled {
+  color: var(--color-text-muted);
+  cursor: default;
 }
 
 /* Disclosure */
@@ -1859,10 +1897,53 @@
     width: 120px;
     height: 120px;
   }
+  .affiliate-card__meta,
   .affiliate-card__footer {
     justify-content: center;
   }
+  .affiliate-card__details {
+    grid-template-columns: 1fr;
+    text-align: left;
+  }
 }
+
+.gear-grid .affiliate-card {
+  flex-direction: column;
+  gap: 0;
+  margin: 0;
+  overflow: hidden;
+  height: 100%;
+  transition: box-shadow 200ms ease, transform 200ms ease;
+}
+.gear-grid .affiliate-card:hover {
+  box-shadow: var(--shadow-lift);
+  transform: translateY(-3px);
+}
+.gear-grid .affiliate-card__image-link,
+.gear-grid .affiliate-card__image-wrap {
+  width: 100%;
+}
+.gear-grid .affiliate-card__image-wrap {
+  aspect-ratio: 3 / 2;
+  height: auto;
+  border-radius: 0;
+}
+.gear-grid .affiliate-card__image-placeholder { font-size: 36px; opacity: 1; }
+.gear-grid .affiliate-card__body { padding: var(--space-5); }
+.gear-grid .affiliate-card__name {
+  font-family: var(--font-body);
+  font-size: 16px;
+  font-weight: 700;
+}
+.gear-grid .affiliate-card__verdict {
+  color: var(--color-text-primary);
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.gear-grid .affiliate-card__footer { margin-top: auto; }
+.gear-grid .affiliate-card__disclosure { border-top: 1px solid var(--color-border); padding-top: var(--space-3); }
 
 /* Affiliate cards section on single posts */
 .affiliate-products-section {

--- a/functions.php
+++ b/functions.php
@@ -1476,11 +1476,15 @@ function rr_affiliate_products_callback( $post ) {
  * Output a single product row in the metabox.
  */
 function rr_affiliate_product_row( $index, $product ) {
-    $name      = isset( $product['name'] )      ? $product['name']      : '';
+    $name      = isset( $product['name'] ) ? $product['name'] : '';
     $image_url = isset( $product['image_url'] ) ? $product['image_url'] : '';
-    $shop_url  = isset( $product['shop_url'] )  ? $product['shop_url']  : '';
-    $verdict   = isset( $product['verdict'] )   ? $product['verdict']   : '';
-    $stars     = isset( $product['stars'] )     ? $product['stars']     : '5';
+    $image_alt = isset( $product['image_alt'] ) ? $product['image_alt'] : '';
+    $shop_url  = isset( $product['shop_url'] ) ? $product['shop_url'] : '';
+    $verdict   = isset( $product['verdict'] ) ? $product['verdict'] : '';
+    $best_for  = isset( $product['best_for'] ) ? $product['best_for'] : '';
+    $pros      = isset( $product['pros'] ) ? $product['pros'] : '';
+    $cons      = isset( $product['cons'] ) ? $product['cons'] : '';
+    $stars     = isset( $product['stars'] ) ? $product['stars'] : '5';
     ?>
     <div class="rr-affiliate-product-row">
         <div class="field-row">
@@ -1500,14 +1504,32 @@ function rr_affiliate_product_row( $index, $product ) {
                 <input type="url" name="rr_products[<?php echo esc_attr( $index ); ?>][image_url]" value="<?php echo esc_url( $image_url ); ?>" placeholder="https://...">
             </div>
             <div class="field">
-                <label><?php esc_html_e( 'Amazon URL', 'rolling-reno' ); ?></label>
-                <input type="url" name="rr_products[<?php echo esc_attr( $index ); ?>][shop_url]" value="<?php echo esc_url( $shop_url ); ?>" placeholder="https://amazon.com/dp/...">
+                <label><?php esc_html_e( 'Image Alt Text', 'rolling-reno' ); ?></label>
+                <input type="text" name="rr_products[<?php echo esc_attr( $index ); ?>][image_alt]" value="<?php echo esc_attr( $image_alt ); ?>" placeholder="Product photo description">
+            </div>
+            <div class="field">
+                <label><?php esc_html_e( 'Product URL (Amazon or direct)', 'rolling-reno' ); ?></label>
+                <input type="url" name="rr_products[<?php echo esc_attr( $index ); ?>][shop_url]" value="<?php echo esc_url( $shop_url ); ?>" placeholder="https://www.amazon.com/dp/... or https://brand.com/product">
             </div>
         </div>
         <div class="field-row">
             <div class="field">
                 <label><?php esc_html_e( 'Verdict / Quote', 'rolling-reno' ); ?></label>
                 <textarea name="rr_products[<?php echo esc_attr( $index ); ?>][verdict]" placeholder="&quot;Used on Build #2 — it's held up for 3 years on the road.&quot;"><?php echo esc_textarea( $verdict ); ?></textarea>
+            </div>
+        </div>
+        <div class="field-row">
+            <div class="field">
+                <label><?php esc_html_e( 'Best For', 'rolling-reno' ); ?></label>
+                <input type="text" name="rr_products[<?php echo esc_attr( $index ); ?>][best_for]" value="<?php echo esc_attr( $best_for ); ?>" placeholder="Weekend builds, full-time vans, small kitchens...">
+            </div>
+            <div class="field">
+                <label><?php esc_html_e( 'Pros (one per line)', 'rolling-reno' ); ?></label>
+                <textarea name="rr_products[<?php echo esc_attr( $index ); ?>][pros]" placeholder="Easy install&#10;Good warranty"><?php echo esc_textarea( $pros ); ?></textarea>
+            </div>
+            <div class="field">
+                <label><?php esc_html_e( 'Watch-outs (one per line)', 'rolling-reno' ); ?></label>
+                <textarea name="rr_products[<?php echo esc_attr( $index ); ?>][cons]" placeholder="Costs more upfront"><?php echo esc_textarea( $cons ); ?></textarea>
             </div>
         </div>
     </div>
@@ -1542,11 +1564,15 @@ function rr_save_affiliate_products( $post_id ) {
                 continue; // Skip empty rows
             }
             $products[] = array(
-                'name'      => sanitize_text_field( $product['name'] ),
-                'image_url' => esc_url_raw( $product['image_url'] ),
-                'shop_url'  => esc_url_raw( $product['shop_url'] ),
-                'verdict'   => sanitize_textarea_field( $product['verdict'] ),
-                'stars'     => absint( $product['stars'] ),
+                'name'      => sanitize_text_field( $product['name'] ?? '' ),
+                'image_url' => esc_url_raw( $product['image_url'] ?? '' ),
+                'image_alt' => sanitize_text_field( $product['image_alt'] ?? '' ),
+                'shop_url'  => esc_url_raw( $product['shop_url'] ?? '' ),
+                'verdict'   => sanitize_textarea_field( $product['verdict'] ?? '' ),
+                'best_for'  => sanitize_text_field( $product['best_for'] ?? '' ),
+                'pros'      => sanitize_textarea_field( $product['pros'] ?? '' ),
+                'cons'      => sanitize_textarea_field( $product['cons'] ?? '' ),
+                'stars'     => absint( $product['stars'] ?? 5 ),
             );
         }
     }
@@ -1554,6 +1580,21 @@ function rr_save_affiliate_products( $post_id ) {
     update_post_meta( $post_id, '_rr_affiliate_products', $products );
 }
 add_action( 'save_post', 'rr_save_affiliate_products' );
+
+/**
+ * Determine whether a URL points to Amazon.
+ *
+ * @param string $url Product URL.
+ * @return bool True for Amazon URLs.
+ */
+function rr_is_amazon_url( $url ) {
+    $host = wp_parse_url( $url, PHP_URL_HOST );
+    if ( empty( $host ) ) {
+        return false;
+    }
+
+    return (bool) preg_match( '/(^|\.)amazon\.[a-z.]+$/i', $host );
+}
 
 /**
  * Add Amazon Associate tag to affiliate URLs.
@@ -1566,9 +1607,8 @@ function rr_affiliate_url( $url ) {
         return $url;
     }
     
-    // Only modify full amazon.com URLs — amzn.to short links do not support
-    // query parameters so appending a tag would break the redirect.
-    if ( strpos( $url, 'amazon.com' ) === false ) {
+    // Only modify Amazon URLs. Direct product URLs are preserved as-is.
+    if ( ! rr_is_amazon_url( $url ) ) {
         return $url;
     }
 
@@ -1644,13 +1684,16 @@ function rr_render_affiliate_products( $post_id = null ) {
                 
                 get_template_part( 'template-parts/affiliate-card', null, array(
                     'image_url'   => $product['image_url'],
-                    'image_alt'   => $product['name'],
+                    'image_alt'   => ! empty( $product['image_alt'] ) ? $product['image_alt'] : $product['name'],
                     'name'        => $product['name'],
                     'verdict'     => $product['verdict'],
                     'stars'       => $stars_emoji,
                     'stars_label' => $stars_label,
                     'shop_url'    => $shop_url,
-                    'shop_label'  => __( 'Shop on Amazon →', 'rolling-reno' ),
+                    'shop_label'  => rr_is_amazon_url( $shop_url ) ? __( 'Shop on Amazon →', 'rolling-reno' ) : __( 'View product →', 'rolling-reno' ),
+                    'best_for'    => isset( $product['best_for'] ) ? $product['best_for'] : '',
+                    'pros'        => ! empty( $product['pros'] ) ? preg_split( '/\r\n|\r|\n/', $product['pros'] ) : array(),
+                    'cons'        => ! empty( $product['cons'] ) ? preg_split( '/\r\n|\r|\n/', $product['cons'] ) : array(),
                 ) );
             endforeach;
             ?>
@@ -1663,7 +1706,7 @@ function rr_render_affiliate_products( $post_id = null ) {
 /**
  * Shortcode to embed a single affiliate product card inline.
  *
- * Usage: [rr_product name="Product Name" url="https://amazon.com/..." image="https://..." verdict="Quote" stars="5"]
+ * Usage: [rr_product name="Product Name" url="https://amazon.com/..." image="https://..." alt="Product photo" verdict="Quote" stars="5" best_for="Weekend builds" pros="Compact|Reliable" cons="Costs more upfront"]
  *
  * @param array $atts Shortcode attributes.
  * @return string HTML output.
@@ -1671,10 +1714,14 @@ function rr_render_affiliate_products( $post_id = null ) {
 function rr_product_shortcode( $atts ) {
     $atts = shortcode_atts( array(
         'name'    => '',
-        'url'     => '',
-        'image'   => '',
-        'verdict' => '',
-        'stars'   => '5',
+        'url'      => '',
+        'image'    => '',
+        'alt'      => '',
+        'verdict'  => '',
+        'stars'    => '5',
+        'best_for' => '',
+        'pros'     => '',
+        'cons'     => '',
     ), $atts, 'rr_product' );
     
     if ( empty( $atts['name'] ) ) {
@@ -1689,13 +1736,16 @@ function rr_product_shortcode( $atts ) {
     ob_start();
     get_template_part( 'template-parts/affiliate-card', null, array(
         'image_url'   => $atts['image'],
-        'image_alt'   => $atts['name'],
+        'image_alt'   => $atts['alt'] ? $atts['alt'] : $atts['name'],
         'name'        => $atts['name'],
         'verdict'     => $atts['verdict'],
         'stars'       => $stars_emoji,
         'stars_label' => $stars_label,
         'shop_url'    => $shop_url,
-        'shop_label'  => __( 'Shop on Amazon →', 'rolling-reno' ),
+        'shop_label'  => rr_is_amazon_url( $shop_url ) ? __( 'Shop on Amazon →', 'rolling-reno' ) : __( 'View product →', 'rolling-reno' ),
+        'best_for'    => $atts['best_for'],
+        'pros'        => ! empty( $atts['pros'] ) ? array_map( 'trim', explode( '|', $atts['pros'] ) ) : array(),
+        'cons'        => ! empty( $atts['cons'] ) ? array_map( 'trim', explode( '|', $atts['cons'] ) ) : array(),
     ) );
     return ob_get_clean();
 }

--- a/functions.php
+++ b/functions.php
@@ -1183,7 +1183,7 @@ function rr_render_post_trust_panel( $post_id = null ) {
                 printf(
                     wp_kses(
                         /* translators: %s: affiliate disclosure URL */
-                        __( 'Some guides include affiliate links. If you buy through them, Rolling Reno may earn a small commission at no extra cost to you. Read the <a href="%s">affiliate disclosure</a>.', 'rolling-reno' ),
+                        __( 'As an Amazon Associate, Mara earns from qualifying purchases. Some guide links may also be affiliate links, at no extra cost to you. Read the <a href="%s">affiliate disclosure</a>.', 'rolling-reno' ),
                         array( 'a' => array( 'href' => array() ) )
                     ),
                     esc_url( home_url( '/affiliate-disclosure/' ) )
@@ -1664,7 +1664,7 @@ function rr_render_affiliate_products( $post_id = null ) {
             printf(
                 /* translators: %s: link to affiliate disclosure page */
                 wp_kses(
-                    __( '<strong>Heads up:</strong> Some links below are affiliate links. If you buy through them, Rolling Reno earns a small commission at no extra cost to you. See our <a href="%s">affiliate disclosure</a> for details.', 'rolling-reno' ),
+                    __( '<strong>Heads up:</strong> As an Amazon Associate, Mara earns from qualifying purchases. Some links below may also be affiliate links, at no extra cost to you. See our <a href="%s">affiliate disclosure</a> for details.', 'rolling-reno' ),
                     array(
                         'strong' => array(),
                         'a'      => array( 'href' => array() ),

--- a/page-gear.php
+++ b/page-gear.php
@@ -22,7 +22,7 @@ get_header();
                     <?php esc_html_e( 'After 3 van builds and 40,000km on the road, here\'s what earned a permanent place in Mara\'s kit.', 'rolling-reno' ); ?>
                 </p>
                 <p class="gear-header__disclosure">
-                    <?php esc_html_e( 'Some links on this page are affiliate links. If you buy through them, Mara earns a small commission — at zero cost to you. She only recommends gear she\'s actually used.', 'rolling-reno' ); ?>
+                    <?php esc_html_e( 'As an Amazon Associate, Mara earns from qualifying purchases. Some links may also be affiliate links, at no cost to you. She only recommends gear she\'s actually used.', 'rolling-reno' ); ?>
                 </p>
             </div>
         </div>

--- a/page-gear.php
+++ b/page-gear.php
@@ -237,57 +237,20 @@ get_header();
 
             <div class="gear-grid">
                 <?php foreach ( $section['products'] as $product ) :
-                    $product['shop_url'] = function_exists( 'rr_affiliate_url' ) ? rr_affiliate_url( $product['shop_url'] ) : $product['shop_url'];
-                    $has_shop_url        = ! empty( $product['shop_url'] ) && '#' !== $product['shop_url'];
-                ?>
-                <div class="gear-product-card">
-                    <?php if ( $has_shop_url ) : ?>
-                    <a
-                        href="<?php echo esc_url( $product['shop_url'] ); ?>"
-                        class="gear-product-card__image-link"
-                        rel="nofollow sponsored"
-                        target="_blank"
-                        aria-label="<?php echo esc_attr( sprintf( __( 'Shop %s on Amazon (affiliate link)', 'rolling-reno' ), $product['name'] ) ); ?>"
-                    >
-                    <?php else : ?>
-                    <div class="gear-product-card__image-link" aria-hidden="true">
-                    <?php endif; ?>
-                        <div class="gear-product-card__image-wrap">
-                            <div class="gear-product-card__image-placeholder" aria-hidden="true">
-                                <?php echo $product['emoji']; ?>
-                            </div>
-                        </div>
-                    <?php if ( $has_shop_url ) : ?>
-                    </a>
-                    <?php else : ?>
-                    </div>
-                    <?php endif; ?>
-                    <div class="gear-product-card__body">
-                        <span class="badge badge--category"><?php echo esc_html( $product['badge'] ); ?></span>
-                        <h3 class="gear-product-card__name"><?php echo esc_html( $product['name'] ); ?></h3>
-                        <div class="gear-product-card__rating" aria-label="<?php echo esc_attr( $product['stars_label'] ); ?>">
-                            <span class="gear-product-card__stars"><?php echo esc_html( $product['stars'] ); ?></span>
-                            <span class="gear-product-card__price"><?php echo esc_html( $product['price'] ); ?></span>
-                        </div>
-                        <p class="gear-product-card__verdict"><?php echo esc_html( $product['verdict'] ); ?></p>
-                        <?php if ( $has_shop_url ) : ?>
-                        <a
-                            href="<?php echo esc_url( $product['shop_url'] ); ?>"
-                            class="gear-product-card__cta"
-                            rel="nofollow sponsored"
-                            target="_blank"
-                            aria-label="<?php echo esc_attr( sprintf( __( 'Shop %s on Amazon (opens in new tab, affiliate link)', 'rolling-reno' ), $product['name'] ) ); ?>"
-                        >
-                            <?php esc_html_e( 'Shop on Amazon →', 'rolling-reno' ); ?>
-                        </a>
-                        <?php else : ?>
-                        <span class="gear-product-card__cta" style="color: var(--color-text-muted); cursor: default;">
-                            <?php esc_html_e( 'Product link coming soon', 'rolling-reno' ); ?>
-                        </span>
-                        <?php endif; ?>
-                    </div>
-                </div>
-                <?php endforeach; ?>
+                    $shop_url = function_exists( 'rr_affiliate_url' ) ? rr_affiliate_url( $product['shop_url'] ) : $product['shop_url'];
+
+                    get_template_part( 'template-parts/affiliate-card', null, array(
+                        'name'        => $product['name'],
+                        'verdict'     => $product['verdict'],
+                        'stars'       => $product['stars'],
+                        'stars_label' => $product['stars_label'],
+                        'price'       => $product['price'],
+                        'shop_url'    => $shop_url,
+                        'shop_label'  => function_exists( 'rr_is_amazon_url' ) && rr_is_amazon_url( $shop_url ) ? __( 'Shop on Amazon →', 'rolling-reno' ) : __( 'View product →', 'rolling-reno' ),
+                        'badge'       => $product['badge'],
+                        'placeholder' => $product['emoji'],
+                    ) );
+                endforeach; ?>
             </div>
         </section>
 

--- a/template-parts/affiliate-card.php
+++ b/template-parts/affiliate-card.php
@@ -1,87 +1,150 @@
 <?php
 /**
  * Rolling Reno v2 — template-parts/affiliate-card.php
- * Reusable affiliate product card component
+ * Reusable affiliate / product recommendation card component.
+ *
+ * Supports exact Amazon or direct product URLs, affiliate disclosure,
+ * image/alt text, optional best-for/pros/cons metadata, and responsive layout.
  *
  * Usage:
  *   get_template_part( 'template-parts/affiliate-card', null, array(
  *       'image_url'   => '...',
  *       'image_alt'   => '...',
  *       'name'        => 'Renogy 200W Solar Starter Kit',
- *       'verdict'     => '"Used on Build #2..."',
+ *       'verdict'     => 'Used on Build #2...',
  *       'stars'       => '★★★★½',
  *       'stars_label' => '4.5 out of 5 stars',
- *       'shop_url'    => 'https://amazon.com/...',
+ *       'shop_url'    => 'https://www.amazon.com/dp/...',
  *       'shop_label'  => 'Shop on Amazon →',
+ *       'badge'       => 'Solar & Power',
+ *       'price'       => '$$',
+ *       'best_for'    => 'First-time electrical builds',
+ *       'pros'        => array( 'Clean install', 'Solid warranty' ),
+ *       'cons'        => array( 'Panels need roof space' ),
+ *       'placeholder' => '☀️',
  *   ) );
- *
- * Or with ACF/post meta — adapt as needed.
  */
 
 $args = isset( $args ) ? $args : array();
 
-$image_url   = isset( $args['image_url'] )   ? $args['image_url']   : '';
-$image_alt   = isset( $args['image_alt'] )   ? $args['image_alt']   : '';
-$name        = isset( $args['name'] )        ? $args['name']        : '';
-$verdict     = isset( $args['verdict'] )     ? $args['verdict']     : '';
-$stars       = isset( $args['stars'] )       ? $args['stars']       : '★★★★★';
-$stars_label = isset( $args['stars_label'] ) ? $args['stars_label'] : '5 out of 5 stars';
-$shop_url    = isset( $args['shop_url'] )    ? $args['shop_url']    : '#';
-$shop_label  = isset( $args['shop_label'] )  ? $args['shop_label']  : __( 'Shop on Amazon →', 'rolling-reno' );
+$image_url     = isset( $args['image_url'] ) ? $args['image_url'] : '';
+$image_alt     = isset( $args['image_alt'] ) ? $args['image_alt'] : '';
+$name          = isset( $args['name'] ) ? $args['name'] : '';
+$verdict       = isset( $args['verdict'] ) ? $args['verdict'] : '';
+$stars         = isset( $args['stars'] ) ? $args['stars'] : '★★★★★';
+$stars_label   = isset( $args['stars_label'] ) ? $args['stars_label'] : '5 out of 5 stars';
+$shop_url      = isset( $args['shop_url'] ) ? $args['shop_url'] : '#';
+$badge         = isset( $args['badge'] ) ? $args['badge'] : __( 'Mara Recommends', 'rolling-reno' );
+$price         = isset( $args['price'] ) ? $args['price'] : '';
+$best_for      = isset( $args['best_for'] ) ? $args['best_for'] : '';
+$pros          = ! empty( $args['pros'] ) && is_array( $args['pros'] ) ? array_filter( $args['pros'] ) : array();
+$cons          = ! empty( $args['cons'] ) && is_array( $args['cons'] ) ? array_filter( $args['cons'] ) : array();
+$placeholder   = isset( $args['placeholder'] ) ? $args['placeholder'] : '🔧';
+$is_amazon_url = function_exists( 'rr_is_amazon_url' ) ? rr_is_amazon_url( $shop_url ) : false;
+$has_shop_url  = ! empty( $shop_url ) && '#' !== $shop_url;
+$shop_label    = isset( $args['shop_label'] ) ? $args['shop_label'] : ( $is_amazon_url ? __( 'Shop on Amazon →', 'rolling-reno' ) : __( 'View product →', 'rolling-reno' ) );
+$cta_context   = $is_amazon_url ? __( 'Amazon affiliate link', 'rolling-reno' ) : __( 'product link', 'rolling-reno' );
 ?>
 
-<div class="affiliate-card" aria-label="<?php esc_attr_e( 'Product recommendation', 'rolling-reno' ); ?>">
-
-    <div class="affiliate-card__image-wrap">
-        <?php if ( $image_url ) : ?>
-            <img
-                src="<?php echo esc_url( $image_url ); ?>"
-                alt="<?php echo esc_attr( $image_alt ); ?>"
-                width="160"
-                height="160"
-                loading="lazy"
-                class="affiliate-card__image"
-            >
-        <?php else : ?>
-            <!-- Placeholder until product imagery is sourced -->
-            <div class="affiliate-card__image-placeholder" aria-hidden="true">🔧</div>
-        <?php endif; ?>
-    </div>
+<article class="affiliate-card" aria-label="<?php echo esc_attr( sprintf( __( 'Product recommendation: %s', 'rolling-reno' ), $name ) ); ?>">
+    <?php if ( $has_shop_url ) : ?>
+    <a
+        href="<?php echo esc_url( $shop_url ); ?>"
+        class="affiliate-card__image-link"
+        rel="nofollow sponsored noopener"
+        target="_blank"
+        aria-label="<?php echo esc_attr( sprintf( __( 'View %1$s (%2$s, opens in new tab)', 'rolling-reno' ), $name, $cta_context ) ); ?>"
+    >
+    <?php endif; ?>
+        <div class="affiliate-card__image-wrap">
+            <?php if ( $image_url ) : ?>
+                <img
+                    src="<?php echo esc_url( $image_url ); ?>"
+                    alt="<?php echo esc_attr( $image_alt ? $image_alt : $name ); ?>"
+                    width="160"
+                    height="160"
+                    loading="lazy"
+                    class="affiliate-card__image"
+                >
+            <?php else : ?>
+                <div class="affiliate-card__image-placeholder" aria-hidden="true"><?php echo esc_html( $placeholder ); ?></div>
+            <?php endif; ?>
+        </div>
+    <?php if ( $has_shop_url ) : ?>
+    </a>
+    <?php endif; ?>
 
     <div class="affiliate-card__body">
-        <span class="affiliate-card__label label-text">
-            <?php esc_html_e( 'Mara Recommends', 'rolling-reno' ); ?>
-        </span>
+        <div class="affiliate-card__header">
+            <?php if ( $badge ) : ?>
+                <span class="affiliate-card__label label-text"><?php echo esc_html( $badge ); ?></span>
+            <?php endif; ?>
 
-        <?php if ( $name ) : ?>
-            <h4 class="affiliate-card__name"><?php echo esc_html( $name ); ?></h4>
+            <?php if ( $name ) : ?>
+                <h4 class="affiliate-card__name"><?php echo esc_html( $name ); ?></h4>
+            <?php endif; ?>
+
+            <div class="affiliate-card__meta">
+                <?php if ( $stars ) : ?>
+                    <span class="affiliate-card__stars" aria-label="<?php echo esc_attr( $stars_label ); ?>"><?php echo esc_html( $stars ); ?></span>
+                <?php endif; ?>
+                <?php if ( $price ) : ?>
+                    <span class="affiliate-card__price"><?php echo esc_html( $price ); ?></span>
+                <?php endif; ?>
+            </div>
+        </div>
+
+        <?php if ( $best_for ) : ?>
+            <p class="affiliate-card__best-for"><strong><?php esc_html_e( 'Best for:', 'rolling-reno' ); ?></strong> <?php echo esc_html( $best_for ); ?></p>
         <?php endif; ?>
 
         <?php if ( $verdict ) : ?>
             <p class="affiliate-card__verdict"><?php echo esc_html( $verdict ); ?></p>
         <?php endif; ?>
 
-        <div class="affiliate-card__footer">
-            <div class="affiliate-card__stars" aria-label="<?php echo esc_attr( $stars_label ); ?>">
-                <?php echo esc_html( $stars ); ?>
+        <?php if ( $pros || $cons ) : ?>
+            <div class="affiliate-card__details">
+                <?php if ( $pros ) : ?>
+                    <div class="affiliate-card__detail-list">
+                        <strong><?php esc_html_e( 'Pros', 'rolling-reno' ); ?></strong>
+                        <ul>
+                            <?php foreach ( $pros as $pro ) : ?>
+                                <li><?php echo esc_html( $pro ); ?></li>
+                            <?php endforeach; ?>
+                        </ul>
+                    </div>
+                <?php endif; ?>
+                <?php if ( $cons ) : ?>
+                    <div class="affiliate-card__detail-list">
+                        <strong><?php esc_html_e( 'Watch-outs', 'rolling-reno' ); ?></strong>
+                        <ul>
+                            <?php foreach ( $cons as $con ) : ?>
+                                <li><?php echo esc_html( $con ); ?></li>
+                            <?php endforeach; ?>
+                        </ul>
+                    </div>
+                <?php endif; ?>
             </div>
+        <?php endif; ?>
 
-            <?php if ( $shop_url && $shop_url !== '#' ) : ?>
+        <div class="affiliate-card__footer">
+            <?php if ( $has_shop_url ) : ?>
                 <a
                     href="<?php echo esc_url( $shop_url ); ?>"
-                    class="btn btn--primary btn--sm"
-                    rel="nofollow sponsored"
+                    class="btn btn--primary btn--sm affiliate-card__cta"
+                    rel="nofollow sponsored noopener"
                     target="_blank"
-                    aria-label="<?php echo esc_attr( sprintf( __( 'Shop %s on Amazon (affiliate link, opens in new tab)', 'rolling-reno' ), $name ) ); ?>"
+                    aria-label="<?php echo esc_attr( sprintf( __( 'View %1$s (%2$s, opens in new tab)', 'rolling-reno' ), $name, $cta_context ) ); ?>"
                 >
                     <?php echo esc_html( $shop_label ); ?>
                 </a>
+            <?php else : ?>
+                <span class="affiliate-card__cta affiliate-card__cta--disabled"><?php esc_html_e( 'Product link coming soon', 'rolling-reno' ); ?></span>
             <?php endif; ?>
         </div>
 
         <p class="affiliate-card__disclosure">
-            <?php esc_html_e( '*Affiliate link — Mara earns a small commission at no cost to you.', 'rolling-reno' ); ?>
+            <?php esc_html_e( '*Some product links are affiliate links. Mara may earn a small commission at no cost to you.', 'rolling-reno' ); ?>
         </p>
     </div>
-
-</div>
+</article>

--- a/template-parts/affiliate-card.php
+++ b/template-parts/affiliate-card.php
@@ -144,7 +144,7 @@ $cta_context   = $is_amazon_url ? __( 'Amazon affiliate link', 'rolling-reno' ) 
         </div>
 
         <p class="affiliate-card__disclosure">
-            <?php esc_html_e( '*Some product links are affiliate links. Mara may earn a small commission at no cost to you.', 'rolling-reno' ); ?>
+            <?php esc_html_e( 'As an Amazon Associate, Mara earns from qualifying purchases. Some links may also be affiliate links, at no cost to you.', 'rolling-reno' ); ?>
         </p>
     </div>
 </article>


### PR DESCRIPTION
## Summary
- expands `template-parts/affiliate-card.php` into the reusable product recommendation component for posts, shortcodes, and the Gear page
- supports exact Amazon URLs and direct product URLs, preserves direct URLs, and applies the Rolling Reno Amazon tag only to Amazon hosts
- adds image alt text, optional best-for/pros/watch-outs metadata, Amazon Associate disclosure, disabled CTA fallback, and responsive Gear grid styling
- refactors `/gear/` to use the shared affiliate card instead of a separate card pattern

## Acceptance criteria / expected outcome
- Gear page and post product recommendations use one reusable affiliate card component.
- Amazon product links include the Rolling Reno Associate tag; direct/non-Amazon links remain unchanged.
- Cards expose clear labels, disclosure, CTA fallback, pros/watch-outs, and mobile-safe layout.

## Changed pages/components/scripts
- Changed pages/components/scripts: `/gear/`, post affiliate product cards, `[rr_product]` shortcode output, `template-parts/affiliate-card.php`, `functions.php`, `page-gear.php`, `assets/css/main.css`.

## Release evidence
- `php -l` on changed PHP files (`functions.php`, `page-gear.php`, `template-parts/affiliate-card.php`): pass after disclosure patch `f540326`.
- CSS brace balance check for `assets/css/main.css` and `assets/css/design-system.css`: pass.
- `npm run test:regression -- --project=desktop-chromium --project=mobile-chromium`: previous PR run passed (10 passed, 4 expected project skips); new run after `f540326` is expected from branch push.
- Branch freshness / rebase note: branch is updated against current `origin/main`; earlier check showed 0 behind / 1 ahead before the disclosure patch, and patch was made on that refreshed head.

## Staging / preview evidence
- Staging now tracks `main`; this PR branch was not manually deployed to staging to avoid reintroducing staging drift.
- Final smoke expectation: after merge, `main` push auto-deploys staging and production; verify `/gear/` and representative post affiliate card on staging after deploy.

## Mobile QA evidence
- Sienna functional QA PASS: static Playwright overflow check passed at 375px and 1280px (`scrollWidth === clientWidth`); template render tests passed for Amazon/direct/disabled CTA states, pros/watch-outs, and rel attributes.
- Aoife visual QA PASS: local static render checked at desktop 1280px and mobile 375px with no horizontal overflow; Gear grid works 3-column desktop and 1-column mobile; post affiliate card stacks cleanly.

## Aoife UI/UX verdict
- PASS. Card hierarchy is clear; CTA styling is brand-consistent/readable; Gear grid and post card layout are mobile-safe.
- Non-blocking notes: per-card disclosure is small/light on mobile, line-clamped Gear verdict text should remain intentional, and mobile pros/watch-outs could use slightly more vertical spacing later.

## Sienna functional verdict
- PASS. URL tests passed for adding/replacing/preserving Amazon tag behavior; direct URLs preserved; template render tests passed for Amazon CTA label + `nofollow sponsored noopener`, direct CTA label, pros/watch-outs, and disabled CTA fallback with no `href`.
- Non-blocking note: Amazon URLs with `#fragment` would append the tag after the fragment; current Gear URLs do not use fragments.

## Sarah copy QA verdict
- Sarah copy QA verdict: APPROVED by Sarah at current PR head `f54032622c5db0d03f8cb953da2c3e2535d06429` for content-affecting files `functions.php`, `page-gear.php`, and `template-parts/affiliate-card.php`; see https://github.com/MJM-Agents/rolling-reno-theme/pull/57#issuecomment-4328989453.
- Initial BLOCK on missing explicit Amazon Associate disclosure was fixed in commit `f540326`.
- Required wording added across Gear header, post trust disclosure, affiliate product section disclosure, and per-card disclosure: “As an Amazon Associate, Mara earns from qualifying purchases…” plus no-cost affiliate wording.
- CTA labels, `Best for`, `Pros`, and `Watch-outs` labels were already clear/trustworthy.

## Rollback
- Revert this PR to restore the prior Gear-specific card markup and the simpler affiliate-card template/metabox fields.

Closes MJM-254
