### PR TITLE
fix(MJM-316): improve mobile article table readability

### DIFF
--- a/style.css
+++ b/style.css
@@ -691,3 +691,67 @@ h4[id] {
     max-width: 100vw;
   }
 }
+
+/* MJM-316: keep multi-column article tables readable on mobile.
+   Draft 227 includes 3–4 column comparison tables that collapse into heavy wrapping
+   at ~335px wide; prefer a contained horizontal scroll over unreadable squeeze. */
+.post-body .wp-block-table,
+.entry-content .wp-block-table,
+.post-body .rr-table-scroll,
+.entry-content .rr-table-scroll {
+  max-width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.post-body table,
+.entry-content table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.post-body th,
+.post-body td,
+.entry-content th,
+.entry-content td {
+  vertical-align: top;
+}
+
+@media (max-width: 760px) {
+  .post-body .wp-block-table,
+  .entry-content .wp-block-table,
+  .post-body .rr-table-scroll,
+  .entry-content .rr-table-scroll {
+    margin-left: -4px;
+    margin-right: -4px;
+    padding: 0 4px 0.45rem;
+    scrollbar-gutter: stable;
+  }
+
+  .post-body .wp-block-table table,
+  .entry-content .wp-block-table table,
+  .post-body .rr-table-scroll table,
+  .entry-content .rr-table-scroll table,
+  .post-body > table,
+  .entry-content > table {
+    min-width: 40rem;
+  }
+
+  .post-body > table,
+  .entry-content > table {
+    display: block;
+    max-width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .post-body th,
+  .post-body td,
+  .entry-content th,
+  .entry-content td {
+    min-width: 9rem;
+    white-space: normal;
+    overflow-wrap: normal;
+    word-break: normal;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a CSS-only mobile readability treatment for article tables in `.post-body` / `.entry-content`.
- WordPress table blocks now stay inside a horizontally scrollable wrapper on mobile instead of squeezing 3–4 columns into ~335px.
- Sets a mobile table min-width and readable cell min-width while keeping overflow contained to the table wrapper.

## Ticket
MJM-316

## Acceptance criteria / expected outcome
- Draft post ID 227 remains Draft; this PR does not publish or edit post status.
- 3–4 column article tables are readable at ~335px mobile width via contained horizontal scroll.
- No page-level horizontal overflow is introduced.
- Existing Rolling Reno regression tests remain green.

## Staging / preview evidence
- Production draft 227 was not published.
- Code is not merged/live yet; Aoife re-QA requested against the PR fix path before merge/deploy.
- Local focused mobile smoke at 335px: `bodyScrollWidth=319`, `bodyClientWidth=319`, table wrapper scrollable (`wrapperScrollWidth=648`, `wrapperClientWidth=287`, `overflow-x:auto`).

## Changed pages/components/scripts
- `style.css` only.
- Affects article/post content tables (`.post-body`, `.entry-content`, `.wp-block-table`, optional `.rr-table-scroll`).

## Validation
- `git diff --check` ✅
- `php -l functions.php` ✅
- Root/template/inc PHP lint ✅
- `npm ci` ✅
- `npm run test:regression` ✅ — 10 passed / 4 skipped
- Focused synthetic 335px Playwright table smoke ✅ — contained body overflow + scrollable table wrapper

## Mobile QA evidence
- Mobile table fix is specifically scoped to `@media (max-width: 760px)`.
- Synthetic 335px viewport validated table wrapper scrolls horizontally while body does not overflow.
- Aoife re-QA PASS for draft post 227 mobile table readability before merge/deploy: no page-level horizontal overflow at 335px; 3-col and 4-col wrappers scroll horizontally inside wrapper; draft 227 was not published or edited.

## QA verdicts
- Aoife UI/UX verdict: PASS — PR diff is CSS-only (`style.css`); local Chrome/Playwright synthetic validation at 335px confirmed no page-level horizontal overflow, 3-col wrapper scrolls `327 client / 648 scroll`, 4-col wrapper scrolls `327 client / 653 scroll`, `overflow-x:auto`, table min-width `640px`, cell min-width `144px`. PR evidence: https://github.com/MJM-Agents/rolling-reno-theme/pull/60#issuecomment-4331417745
- Sienna functional: N/A — CSS-only article readability fix; existing regression suite passed.
- Sarah copy QA verdict: N/A — no copy, marketing text, labels, or blog content changed; CSS-only article table treatment.

## Branch freshness
- Branch freshness: branch is current with `origin/main` (`0 behind / 1 ahead`) as verified by Cian on 2026-04-27; GitHub reports `mergeable=MERGEABLE`. `mergeStateStatus=BLOCKED` is caused by the prior request-changes review state, not a stale branch.

## Rollback
- Revert this PR; it only appends a scoped CSS block to `style.css`.


