### PR TITLE
MJM-286: Fix Rolling Reno nav links and gear product images

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -508,6 +508,11 @@
   background: var(--color-sand);
 }
 .gear-card__image { width: 100%; height: 100%; object-fit: cover; }
+.gear-card__image[src$=".svg"] {
+  object-fit: contain;
+  padding: var(--space-2);
+  background: var(--color-sand);
+}
 .gear-card__image-placeholder {
   width: 100%;
   height: 100%;
@@ -539,9 +544,13 @@
   line-height: 1.5;
 }
 .gear-card__cta {
+  align-items: center;
   font-size: 13px;
   font-weight: 700;
   color: var(--color-terracotta);
+  display: inline-flex;
+  min-height: 44px;
+  padding: 10px 0;
   text-decoration: none;
   margin-top: auto;
 }
@@ -1579,6 +1588,11 @@
   background: var(--color-sand);
 }
 .gear-product-card__image { width: 100%; height: 100%; object-fit: cover; transition: transform 300ms ease; }
+.gear-product-card__image[src$=".svg"] {
+  object-fit: contain;
+  padding: var(--space-3);
+  background: var(--color-sand);
+}
 .gear-product-card:hover .gear-product-card__image { transform: scale(1.03); }
 .gear-product-card__image-placeholder {
   width: 100%; height: 100%;

--- a/assets/images/gear/3m-thinsulate-sm600l.svg
+++ b/assets/images/gear/3m-thinsulate-sm600l.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 600" role="img" aria-labelledby="title desc">
+  <title id="title">3M Thinsulate Insulation</title>
+  <desc id="desc">Styled Rolling Reno product illustration for 3M Thinsulate Insulation.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#E9D8A6" stop-opacity="0.95"/>
+      <stop offset="1" stop-color="#F9F3E7"/>
+    </linearGradient>
+    <filter id="shadow" x="-10%" y="-10%" width="120%" height="120%"><feDropShadow dx="0" dy="18" stdDeviation="18" flood-color="#1f211d" flood-opacity="0.18"/></filter>
+  </defs>
+  <rect width="900" height="600" rx="48" fill="url(#bg)"/>
+  <circle cx="760" cy="95" r="120" fill="#fff" opacity="0.22"/>
+  <circle cx="120" cy="520" r="170" fill="#1f211d" opacity="0.08"/>
+  <g filter="url(#shadow)">
+    <rect x="185" y="105" width="530" height="330" rx="42" fill="#fffaf1"/>
+    <rect x="225" y="145" width="450" height="250" rx="32" fill="#596157" opacity="0.1"/>
+    <text x="450" y="282" text-anchor="middle" dominant-baseline="middle" font-size="118">🌡️</text>
+  </g>
+  <text x="450" y="492" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="42" font-weight="800" fill="#596157">3M Thinsulate</text>
+  <text x="450" y="542" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="700" fill="#596157" opacity="0.84">Insulation</text>
+</svg>

--- a/assets/images/gear/aeropress-coffee-maker.svg
+++ b/assets/images/gear/aeropress-coffee-maker.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 600" role="img" aria-labelledby="title desc">
+  <title id="title">Aeropress Coffee Maker</title>
+  <desc id="desc">Styled Rolling Reno product illustration for Aeropress Coffee Maker.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#B08968" stop-opacity="0.95"/>
+      <stop offset="1" stop-color="#F9F3E7"/>
+    </linearGradient>
+    <filter id="shadow" x="-10%" y="-10%" width="120%" height="120%"><feDropShadow dx="0" dy="18" stdDeviation="18" flood-color="#1f211d" flood-opacity="0.18"/></filter>
+  </defs>
+  <rect width="900" height="600" rx="48" fill="url(#bg)"/>
+  <circle cx="760" cy="95" r="120" fill="#fff" opacity="0.22"/>
+  <circle cx="120" cy="520" r="170" fill="#1f211d" opacity="0.08"/>
+  <g filter="url(#shadow)">
+    <rect x="185" y="105" width="530" height="330" rx="42" fill="#fffaf1"/>
+    <rect x="225" y="145" width="450" height="250" rx="32" fill="#3E2F28" opacity="0.1"/>
+    <text x="450" y="282" text-anchor="middle" dominant-baseline="middle" font-size="118">☕</text>
+  </g>
+  <text x="450" y="492" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="42" font-weight="800" fill="#3E2F28">Aeropress Coffee</text>
+  <text x="450" y="542" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="700" fill="#3E2F28" opacity="0.84">Maker</text>
+</svg>

--- a/assets/images/gear/bougerv-40a-mppt-controller.svg
+++ b/assets/images/gear/bougerv-40a-mppt-controller.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 600" role="img" aria-labelledby="title desc">
+  <title id="title">BougeRV MPPT Controller</title>
+  <desc id="desc">Styled Rolling Reno product illustration for BougeRV MPPT Controller.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#F2994A" stop-opacity="0.95"/>
+      <stop offset="1" stop-color="#F9F3E7"/>
+    </linearGradient>
+    <filter id="shadow" x="-10%" y="-10%" width="120%" height="120%"><feDropShadow dx="0" dy="18" stdDeviation="18" flood-color="#1f211d" flood-opacity="0.18"/></filter>
+  </defs>
+  <rect width="900" height="600" rx="48" fill="url(#bg)"/>
+  <circle cx="760" cy="95" r="120" fill="#fff" opacity="0.22"/>
+  <circle cx="120" cy="520" r="170" fill="#1f211d" opacity="0.08"/>
+  <g filter="url(#shadow)">
+    <rect x="185" y="105" width="530" height="330" rx="42" fill="#fffaf1"/>
+    <rect x="225" y="145" width="450" height="250" rx="32" fill="#344E41" opacity="0.1"/>
+    <text x="450" y="282" text-anchor="middle" dominant-baseline="middle" font-size="118">⚡</text>
+  </g>
+  <text x="450" y="492" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="42" font-weight="800" fill="#344E41">BougeRV MPPT</text>
+  <text x="450" y="542" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="700" fill="#344E41" opacity="0.84">Controller</text>
+</svg>

--- a/assets/images/gear/campingaz-double-burner.svg
+++ b/assets/images/gear/campingaz-double-burner.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 600" role="img" aria-labelledby="title desc">
+  <title id="title">Campingaz Stove</title>
+  <desc id="desc">Styled Rolling Reno product illustration for Campingaz Stove.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#E76F51" stop-opacity="0.95"/>
+      <stop offset="1" stop-color="#F9F3E7"/>
+    </linearGradient>
+    <filter id="shadow" x="-10%" y="-10%" width="120%" height="120%"><feDropShadow dx="0" dy="18" stdDeviation="18" flood-color="#1f211d" flood-opacity="0.18"/></filter>
+  </defs>
+  <rect width="900" height="600" rx="48" fill="url(#bg)"/>
+  <circle cx="760" cy="95" r="120" fill="#fff" opacity="0.22"/>
+  <circle cx="120" cy="520" r="170" fill="#1f211d" opacity="0.08"/>
+  <g filter="url(#shadow)">
+    <rect x="185" y="105" width="530" height="330" rx="42" fill="#fffaf1"/>
+    <rect x="225" y="145" width="450" height="250" rx="32" fill="#4B2E24" opacity="0.1"/>
+    <text x="450" y="282" text-anchor="middle" dominant-baseline="middle" font-size="118">🔥</text>
+  </g>
+  <text x="450" y="492" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="42" font-weight="800" fill="#4B2E24">Campingaz Stove</text>
+  <text x="450" y="542" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="700" fill="#4B2E24" opacity="0.84"></text>
+</svg>

--- a/assets/images/gear/dometic-cfx3-fridge.svg
+++ b/assets/images/gear/dometic-cfx3-fridge.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 600" role="img" aria-labelledby="title desc">
+  <title id="title">Dometic CFX3 Fridge</title>
+  <desc id="desc">Styled Rolling Reno product illustration for Dometic CFX3 Fridge.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#A7D8E8" stop-opacity="0.95"/>
+      <stop offset="1" stop-color="#F9F3E7"/>
+    </linearGradient>
+    <filter id="shadow" x="-10%" y="-10%" width="120%" height="120%"><feDropShadow dx="0" dy="18" stdDeviation="18" flood-color="#1f211d" flood-opacity="0.18"/></filter>
+  </defs>
+  <rect width="900" height="600" rx="48" fill="url(#bg)"/>
+  <circle cx="760" cy="95" r="120" fill="#fff" opacity="0.22"/>
+  <circle cx="120" cy="520" r="170" fill="#1f211d" opacity="0.08"/>
+  <g filter="url(#shadow)">
+    <rect x="185" y="105" width="530" height="330" rx="42" fill="#fffaf1"/>
+    <rect x="225" y="145" width="450" height="250" rx="32" fill="#2F5F73" opacity="0.1"/>
+    <text x="450" y="282" text-anchor="middle" dominant-baseline="middle" font-size="118">🧊</text>
+  </g>
+  <text x="450" y="492" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="42" font-weight="800" fill="#2F5F73">Dometic CFX3</text>
+  <text x="450" y="542" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="700" fill="#2F5F73" opacity="0.84">Fridge</text>
+</svg>

--- a/assets/images/gear/glinet-slate-ax-router.svg
+++ b/assets/images/gear/glinet-slate-ax-router.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 600" role="img" aria-labelledby="title desc">
+  <title id="title">GL.iNet Slate AX Router</title>
+  <desc id="desc">Styled Rolling Reno product illustration for GL.iNet Slate AX Router.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#A3B18A" stop-opacity="0.95"/>
+      <stop offset="1" stop-color="#F9F3E7"/>
+    </linearGradient>
+    <filter id="shadow" x="-10%" y="-10%" width="120%" height="120%"><feDropShadow dx="0" dy="18" stdDeviation="18" flood-color="#1f211d" flood-opacity="0.18"/></filter>
+  </defs>
+  <rect width="900" height="600" rx="48" fill="url(#bg)"/>
+  <circle cx="760" cy="95" r="120" fill="#fff" opacity="0.22"/>
+  <circle cx="120" cy="520" r="170" fill="#1f211d" opacity="0.08"/>
+  <g filter="url(#shadow)">
+    <rect x="185" y="105" width="530" height="330" rx="42" fill="#fffaf1"/>
+    <rect x="225" y="145" width="450" height="250" rx="32" fill="#253329" opacity="0.1"/>
+    <text x="450" y="282" text-anchor="middle" dominant-baseline="middle" font-size="118">📡</text>
+  </g>
+  <text x="450" y="492" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="42" font-weight="800" fill="#253329">GL.iNet Slate</text>
+  <text x="450" y="542" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="700" fill="#253329" opacity="0.84">AX Router</text>
+</svg>

--- a/assets/images/gear/kidde-co-detector.svg
+++ b/assets/images/gear/kidde-co-detector.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 600" role="img" aria-labelledby="title desc">
+  <title id="title">Kidde CO Detector</title>
+  <desc id="desc">Styled Rolling Reno product illustration for Kidde CO Detector.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#E5E5E5" stop-opacity="0.95"/>
+      <stop offset="1" stop-color="#F9F3E7"/>
+    </linearGradient>
+    <filter id="shadow" x="-10%" y="-10%" width="120%" height="120%"><feDropShadow dx="0" dy="18" stdDeviation="18" flood-color="#1f211d" flood-opacity="0.18"/></filter>
+  </defs>
+  <rect width="900" height="600" rx="48" fill="url(#bg)"/>
+  <circle cx="760" cy="95" r="120" fill="#fff" opacity="0.22"/>
+  <circle cx="120" cy="520" r="170" fill="#1f211d" opacity="0.08"/>
+  <g filter="url(#shadow)">
+    <rect x="185" y="105" width="530" height="330" rx="42" fill="#fffaf1"/>
+    <rect x="225" y="145" width="450" height="250" rx="32" fill="#343A40" opacity="0.1"/>
+    <text x="450" y="282" text-anchor="middle" dominant-baseline="middle" font-size="118">🛡️</text>
+  </g>
+  <text x="450" y="492" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="42" font-weight="800" fill="#343A40">Kidde CO</text>
+  <text x="450" y="542" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="700" fill="#343A40" opacity="0.84">Detector</text>
+</svg>

--- a/assets/images/gear/latex-van-mattress.svg
+++ b/assets/images/gear/latex-van-mattress.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 600" role="img" aria-labelledby="title desc">
+  <title id="title">Natural Latex Van Mattress</title>
+  <desc id="desc">Styled Rolling Reno product illustration for Natural Latex Van Mattress.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#D6C7A8" stop-opacity="0.95"/>
+      <stop offset="1" stop-color="#F9F3E7"/>
+    </linearGradient>
+    <filter id="shadow" x="-10%" y="-10%" width="120%" height="120%"><feDropShadow dx="0" dy="18" stdDeviation="18" flood-color="#1f211d" flood-opacity="0.18"/></filter>
+  </defs>
+  <rect width="900" height="600" rx="48" fill="url(#bg)"/>
+  <circle cx="760" cy="95" r="120" fill="#fff" opacity="0.22"/>
+  <circle cx="120" cy="520" r="170" fill="#1f211d" opacity="0.08"/>
+  <g filter="url(#shadow)">
+    <rect x="185" y="105" width="530" height="330" rx="42" fill="#fffaf1"/>
+    <rect x="225" y="145" width="450" height="250" rx="32" fill="#5C5346" opacity="0.1"/>
+    <text x="450" y="282" text-anchor="middle" dominant-baseline="middle" font-size="118">🛏️</text>
+  </g>
+  <text x="450" y="492" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="42" font-weight="800" fill="#5C5346">Natural Latex</text>
+  <text x="450" y="542" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="700" fill="#5C5346" opacity="0.84">Van Mattress</text>
+</svg>

--- a/assets/images/gear/lifepo4-100ah-battery.svg
+++ b/assets/images/gear/lifepo4-100ah-battery.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 600" role="img" aria-labelledby="title desc">
+  <title id="title">100Ah Lithium Battery</title>
+  <desc id="desc">Styled Rolling Reno product illustration for 100Ah Lithium Battery.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#8BBF9F" stop-opacity="0.95"/>
+      <stop offset="1" stop-color="#F9F3E7"/>
+    </linearGradient>
+    <filter id="shadow" x="-10%" y="-10%" width="120%" height="120%"><feDropShadow dx="0" dy="18" stdDeviation="18" flood-color="#1f211d" flood-opacity="0.18"/></filter>
+  </defs>
+  <rect width="900" height="600" rx="48" fill="url(#bg)"/>
+  <circle cx="760" cy="95" r="120" fill="#fff" opacity="0.22"/>
+  <circle cx="120" cy="520" r="170" fill="#1f211d" opacity="0.08"/>
+  <g filter="url(#shadow)">
+    <rect x="185" y="105" width="530" height="330" rx="42" fill="#fffaf1"/>
+    <rect x="225" y="145" width="450" height="250" rx="32" fill="#243B35" opacity="0.1"/>
+    <text x="450" y="282" text-anchor="middle" dominant-baseline="middle" font-size="118">🔋</text>
+  </g>
+  <text x="450" y="492" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="42" font-weight="800" fill="#243B35">100Ah Lithium</text>
+  <text x="450" y="542" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="700" fill="#243B35" opacity="0.84">Battery</text>
+</svg>

--- a/assets/images/gear/renogy-200w-solar-kit.svg
+++ b/assets/images/gear/renogy-200w-solar-kit.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 600" role="img" aria-labelledby="title desc">
+  <title id="title">Renogy 200W Solar Kit</title>
+  <desc id="desc">Styled Rolling Reno product illustration for Renogy 200W Solar Kit.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#F6C453" stop-opacity="0.95"/>
+      <stop offset="1" stop-color="#F9F3E7"/>
+    </linearGradient>
+    <filter id="shadow" x="-10%" y="-10%" width="120%" height="120%"><feDropShadow dx="0" dy="18" stdDeviation="18" flood-color="#1f211d" flood-opacity="0.18"/></filter>
+  </defs>
+  <rect width="900" height="600" rx="48" fill="url(#bg)"/>
+  <circle cx="760" cy="95" r="120" fill="#fff" opacity="0.22"/>
+  <circle cx="120" cy="520" r="170" fill="#1f211d" opacity="0.08"/>
+  <g filter="url(#shadow)">
+    <rect x="185" y="105" width="530" height="330" rx="42" fill="#fffaf1"/>
+    <rect x="225" y="145" width="450" height="250" rx="32" fill="#2E5E4E" opacity="0.1"/>
+    <text x="450" y="282" text-anchor="middle" dominant-baseline="middle" font-size="118">☀️</text>
+  </g>
+  <text x="450" y="492" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="42" font-weight="800" fill="#2E5E4E">Renogy 200W</text>
+  <text x="450" y="542" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="700" fill="#2E5E4E" opacity="0.84">Solar Kit</text>
+</svg>

--- a/assets/images/gear/sea-to-summit-liner.svg
+++ b/assets/images/gear/sea-to-summit-liner.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 600" role="img" aria-labelledby="title desc">
+  <title id="title">Sleeping Bag Liner</title>
+  <desc id="desc">Styled Rolling Reno product illustration for Sleeping Bag Liner.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#7C8FA6" stop-opacity="0.95"/>
+      <stop offset="1" stop-color="#F9F3E7"/>
+    </linearGradient>
+    <filter id="shadow" x="-10%" y="-10%" width="120%" height="120%"><feDropShadow dx="0" dy="18" stdDeviation="18" flood-color="#1f211d" flood-opacity="0.18"/></filter>
+  </defs>
+  <rect width="900" height="600" rx="48" fill="url(#bg)"/>
+  <circle cx="760" cy="95" r="120" fill="#fff" opacity="0.22"/>
+  <circle cx="120" cy="520" r="170" fill="#1f211d" opacity="0.08"/>
+  <g filter="url(#shadow)">
+    <rect x="185" y="105" width="530" height="330" rx="42" fill="#fffaf1"/>
+    <rect x="225" y="145" width="450" height="250" rx="32" fill="#26364A" opacity="0.1"/>
+    <text x="450" y="282" text-anchor="middle" dominant-baseline="middle" font-size="118">🌙</text>
+  </g>
+  <text x="450" y="492" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="42" font-weight="800" fill="#26364A">Sleeping Bag</text>
+  <text x="450" y="542" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="700" fill="#26364A" opacity="0.84">Liner</text>
+</svg>

--- a/assets/images/gear/webasto-diesel-heater.svg
+++ b/assets/images/gear/webasto-diesel-heater.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 600" role="img" aria-labelledby="title desc">
+  <title id="title">Webasto Diesel Heater</title>
+  <desc id="desc">Styled Rolling Reno product illustration for Webasto Diesel Heater.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#D65A31" stop-opacity="0.95"/>
+      <stop offset="1" stop-color="#F9F3E7"/>
+    </linearGradient>
+    <filter id="shadow" x="-10%" y="-10%" width="120%" height="120%"><feDropShadow dx="0" dy="18" stdDeviation="18" flood-color="#1f211d" flood-opacity="0.18"/></filter>
+  </defs>
+  <rect width="900" height="600" rx="48" fill="url(#bg)"/>
+  <circle cx="760" cy="95" r="120" fill="#fff" opacity="0.22"/>
+  <circle cx="120" cy="520" r="170" fill="#1f211d" opacity="0.08"/>
+  <g filter="url(#shadow)">
+    <rect x="185" y="105" width="530" height="330" rx="42" fill="#fffaf1"/>
+    <rect x="225" y="145" width="450" height="250" rx="32" fill="#3A2A24" opacity="0.1"/>
+    <text x="450" y="282" text-anchor="middle" dominant-baseline="middle" font-size="118">🔥</text>
+  </g>
+  <text x="450" y="492" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="42" font-weight="800" fill="#3A2A24">Webasto Diesel</text>
+  <text x="450" y="542" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="700" fill="#3A2A24" opacity="0.84">Heater</text>
+</svg>

--- a/footer.php
+++ b/footer.php
@@ -98,10 +98,10 @@
 function rr_footer_explore_fallback() {
     $links = array(
         array( home_url( '/start-here' ), __( 'Start Here',  'rolling-reno' ) ),
-        array( home_url( '/van-life' ),   __( 'Van Life',    'rolling-reno' ) ),
-        array( home_url( '/rv-life' ),    __( 'RV Life',     'rolling-reno' ) ),
+        array( rr_topic_url( 'van-life' ), __( 'Van Life',    'rolling-reno' ) ),
+        array( rr_topic_url( 'rv-life' ),  __( 'RV Life',     'rolling-reno' ) ),
         array( home_url( '/gear' ),       __( 'Gear & Kit',  'rolling-reno' ) ),
-        array( home_url( '/van-life/maras-rig' ), __( "Mara's Rig", 'rolling-reno' ) ),
+        array( rr_topic_url( 'van-life' ), __( 'Van Life Guides', 'rolling-reno' ) ),
     );
     echo '<nav aria-label="' . esc_attr__( 'Footer Explore', 'rolling-reno' ) . '">';
     foreach ( $links as $l ) {

--- a/front-page.php
+++ b/front-page.php
@@ -161,7 +161,7 @@ $mara_about_img = get_theme_mod( 'rr_mara_about_image', '' );
             $tiles = array(
                 array(
                     'label'  => __( 'Van Life', 'rolling-reno' ),
-                    'url'    => home_url( '/van-life' ),
+                    'url'    => rr_topic_url( 'van-life' ),
                     'class'  => 'category-tile__placeholder--van-life',
                     'emoji'  => '🚐',
                     'aria'   => __( 'Browse Van Life posts', 'rolling-reno' ),
@@ -169,7 +169,7 @@ $mara_about_img = get_theme_mod( 'rr_mara_about_image', '' );
                 ),
                 array(
                     'label'  => __( 'RV Life', 'rolling-reno' ),
-                    'url'    => home_url( '/rv-life' ),
+                    'url'    => rr_topic_url( 'rv-life' ),
                     'class'  => 'category-tile__placeholder--rv-life',
                     'emoji'  => '🏕️',
                     'aria'   => __( 'Browse RV Life posts', 'rolling-reno' ),
@@ -184,11 +184,11 @@ $mara_about_img = get_theme_mod( 'rr_mara_about_image', '' );
                     'img_key'=> 'rr_cat_img_gear',
                 ),
                 array(
-                    'label'  => __( "Mara's Rig", 'rolling-reno' ),
-                    'url'    => home_url( '/van-life/maras-rig' ),
+                    'label'  => __( 'Van Life Guides', 'rolling-reno' ),
+                    'url'    => rr_topic_url( 'van-life' ),
                     'class'  => 'category-tile__placeholder--maras-rig',
                     'emoji'  => '🌿',
-                    'aria'   => __( "Browse Mara's Rig posts", 'rolling-reno' ),
+                    'aria'   => __( 'Browse Van Life guides', 'rolling-reno' ),
                     'img_key'=> 'rr_cat_img_maras_rig',
                 ),
             );
@@ -374,23 +374,27 @@ $mara_about_img = get_theme_mod( 'rr_mara_about_image', '' );
         </header>
         <div class="gear-strip__scroll">
             <?php
-            // Gear spotlight — query posts tagged or categorised as gear
-            $gear_query = new WP_Query( array(
-                'posts_per_page' => 8,
-                'category_name'  => 'gear',
-            ) );
+            $featured_gear = array(
+                array( 'Renogy 200W Monocrystalline Solar Starter Kit', __( 'First recommendation for anyone starting out — clean install, solid warranty.', 'rolling-reno' ) ),
+                array( 'Webasto Air Top 2000 STC Diesel Heater', __( 'Survived three Irish winters with this. Non-negotiable.', 'rolling-reno' ) ),
+                array( 'BougeRV 40A MPPT Solar Charge Controller', __( 'Upgraded from a PWM and wished I\'d done it on Build #1.', 'rolling-reno' ) ),
+                array( '3M Thinsulate SM600L Automotive Insulation', __( 'The only van insulation I recommend now. Not even close.', 'rolling-reno' ) ),
+                array( 'Dometic CFX3 25L Compressor Fridge', __( 'Changed everything about how I eat on the road.', 'rolling-reno' ) ),
+            );
 
-            if ( $gear_query->have_posts() ) :
-                while ( $gear_query->have_posts() ) :
-                    $gear_query->the_post();
-                    $thumb = rr_get_post_image_url( get_the_ID(), 'rr-card-sm' );
+            foreach ( $featured_gear as $gear_item ) :
+                $gear_name  = $gear_item[0];
+                $gear_blurb = $gear_item[1];
+                $gear_image = function_exists( 'rr_featured_gear_asset' ) ? rr_featured_gear_asset( $gear_name, 'image' ) : '';
+                $gear_url   = function_exists( 'rr_featured_gear_asset' ) ? rr_featured_gear_asset( $gear_name, 'url' ) : home_url( '/gear' );
+                $gear_url   = function_exists( 'rr_affiliate_url' ) ? rr_affiliate_url( $gear_url ) : $gear_url;
             ?>
             <div class="gear-card">
                 <div class="gear-card__image-wrap">
-                    <?php if ( $thumb ) : ?>
+                    <?php if ( $gear_image ) : ?>
                         <img
-                            src="<?php echo esc_url( $thumb ); ?>"
-                            alt="<?php the_title_attribute(); ?>"
+                            src="<?php echo esc_url( $gear_image ); ?>"
+                            alt="<?php echo esc_attr( $gear_name ); ?>"
                             class="gear-card__image"
                             width="220"
                             height="147"
@@ -401,45 +405,20 @@ $mara_about_img = get_theme_mod( 'rr_mara_about_image', '' );
                     <?php endif; ?>
                 </div>
                 <div class="gear-card__body">
-                    <p class="gear-card__name"><?php the_title(); ?></p>
-                    <p class="gear-card__verdict"><?php echo esc_html( rr_excerpt( null, 12 ) ); ?></p>
+                    <p class="gear-card__name"><?php echo esc_html( $gear_name ); ?></p>
+                    <p class="gear-card__verdict"><?php echo esc_html( $gear_blurb ); ?></p>
                     <a
-                        href="<?php the_permalink(); ?>"
+                        href="<?php echo esc_url( $gear_url ); ?>"
                         class="gear-card__cta"
-                        aria-label="<?php echo esc_attr( sprintf( __( 'Read about %s', 'rolling-reno' ), get_the_title() ) ); ?>"
+                        rel="nofollow sponsored noopener"
+                        target="_blank"
+                        aria-label="<?php echo esc_attr( sprintf( __( 'Shop %s on Amazon (affiliate link, opens in new tab)', 'rolling-reno' ), $gear_name ) ); ?>"
                     >
                         <?php esc_html_e( 'Shop →', 'rolling-reno' ); ?>
                     </a>
                 </div>
             </div>
-            <?php
-                endwhile;
-                wp_reset_postdata();
-            else : ?>
-                <?php // Placeholder cards when no gear posts exist ?>
-                <?php
-                $placeholder_gear = array(
-                    array( 'Renogy 200W Solar Kit', '"First recommendation for anyone starting out — clean install, solid warranty."', '☀️' ),
-                    array( 'Webasto Diesel Heater', '"Survived three Irish winters with this. Non-negotiable."', '🔥' ),
-                    array( 'BougeRV 40A MPPT', '"Upgraded from a PWM and wished I\'d done it Build #1."', '⚡' ),
-                    array( 'Thinsulate SM600L', '"The only van insulation I recommend now. Not even close."', '🌡️' ),
-                    array( 'Dometic CFX3 25L Fridge', '"Changed everything about how I eat on the road."', '🧊' ),
-                );
-                foreach ( $placeholder_gear as $pg ) : ?>
-                <div class="gear-card">
-                    <div class="gear-card__image-wrap">
-                        <div class="gear-card__image-placeholder" aria-hidden="true"><?php echo $pg[2]; ?></div>
-                    </div>
-                    <div class="gear-card__body">
-                        <p class="gear-card__name"><?php echo esc_html( $pg[0] ); ?></p>
-                        <p class="gear-card__verdict"><?php echo esc_html( $pg[1] ); ?></p>
-                        <a href="<?php echo esc_url( home_url( '/gear' ) ); ?>" class="gear-card__cta">
-                            <?php esc_html_e( 'Shop →', 'rolling-reno' ); ?>
-                        </a>
-                    </div>
-                </div>
-                <?php endforeach; ?>
-            <?php endif; ?>
+            <?php endforeach; ?>
         </div>
         <div class="gear-strip__footer">
             <a href="<?php echo esc_url( home_url( '/gear' ) ); ?>" class="btn btn--ghost">

--- a/functions.php
+++ b/functions.php
@@ -900,6 +900,74 @@ function rr_blog_index_url() {
     return $posts_page ? get_permalink( $posts_page ) : home_url( '/blog/' );
 }
 
+/**
+ * Return the canonical URL for topic/category links that should never land on
+ * intentionally blank WordPress pages.
+ */
+function rr_topic_url( $slug ) {
+    $term = get_category_by_slug( $slug );
+    if ( $term && ! is_wp_error( $term ) ) {
+        $url = get_category_link( $term );
+        if ( $url && ! is_wp_error( $url ) ) {
+            return $url;
+        }
+    }
+
+    return home_url( '/category/' . trim( $slug, '/' ) . '/' );
+}
+
+/**
+ * Normalize primary nav menu items that were created as empty pages before the
+ * category archives existed.
+ */
+function rr_rewrite_empty_topic_nav_items( $items ) {
+    foreach ( $items as $item ) {
+        $label = strtolower( trim( wp_strip_all_tags( $item->title ) ) );
+        if ( 'van life' === $label ) {
+            $item->url = rr_topic_url( 'van-life' );
+        } elseif ( 'rv life' === $label ) {
+            $item->url = rr_topic_url( 'rv-life' );
+        }
+    }
+
+    return $items;
+}
+add_filter( 'wp_nav_menu_objects', 'rr_rewrite_empty_topic_nav_items', 20 );
+
+/**
+ * Owned product illustrations and Amazon search URLs for Gear/Home cards.
+ * Images are local SVGs so the site is not depending on scraped Amazon assets.
+ */
+function rr_featured_gear_assets() {
+    $base = get_template_directory_uri() . '/assets/images/gear/';
+
+    return array(
+        'Renogy 200W Monocrystalline Solar Starter Kit' => array( 'image' => $base . 'renogy-200w-solar-kit.svg', 'url' => 'https://www.amazon.com/s?k=Renogy+200W+Monocrystalline+Solar+Starter+Kit' ),
+        'BougeRV 40A MPPT Solar Charge Controller'      => array( 'image' => $base . 'bougerv-40a-mppt-controller.svg', 'url' => 'https://www.amazon.com/s?k=BougeRV+40A+MPPT+Solar+Charge+Controller' ),
+        'Lithium Iron Phosphate 100Ah Battery'          => array( 'image' => $base . 'lifepo4-100ah-battery.svg', 'url' => 'https://www.amazon.com/s?k=LiFePO4+100Ah+Battery' ),
+        'Dometic CFX3 25L Compressor Fridge'            => array( 'image' => $base . 'dometic-cfx3-fridge.svg', 'url' => 'https://www.amazon.com/s?k=Dometic+CFX3+25L+Compressor+Fridge' ),
+        'Campingaz Double Burner Camp Stove'            => array( 'image' => $base . 'campingaz-double-burner.svg', 'url' => 'https://www.amazon.com/s?k=Campingaz+Double+Burner+Camp+Stove' ),
+        'Aeropress Coffee Maker'                        => array( 'image' => $base . 'aeropress-coffee-maker.svg', 'url' => 'https://www.amazon.com/s?k=AeroPress+Coffee+Maker' ),
+        'Rock&Road 100% Natural Latex Van Mattress'     => array( 'image' => $base . 'latex-van-mattress.svg', 'url' => 'https://www.amazon.com/s?k=natural+latex+van+mattress' ),
+        'Sea to Summit Reactor Extreme Sleeping Bag Liner' => array( 'image' => $base . 'sea-to-summit-liner.svg', 'url' => 'https://www.amazon.com/s?k=Sea+to+Summit+Reactor+Extreme+Sleeping+Bag+Liner' ),
+        '3M Thinsulate SM600L Automotive Insulation'    => array( 'image' => $base . '3m-thinsulate-sm600l.svg', 'url' => 'https://www.amazon.com/s?k=3M+Thinsulate+SM600L+Automotive+Insulation' ),
+        'Webasto Air Top 2000 STC Diesel Heater'        => array( 'image' => $base . 'webasto-diesel-heater.svg', 'url' => 'https://www.amazon.com/s?k=Webasto+Air+Top+2000+STC+Diesel+Heater' ),
+        'Kidde KN-COPP-3 Carbon Monoxide Detector'      => array( 'image' => $base . 'kidde-co-detector.svg', 'url' => 'https://www.amazon.com/s?k=Kidde+KN-COPP-3+Carbon+Monoxide+Detector' ),
+        'GL.iNet Slate AX Wi-Fi 6 Travel Router'        => array( 'image' => $base . 'glinet-slate-ax-router.svg', 'url' => 'https://www.amazon.com/s?k=GL.iNet+Slate+AX+Wi-Fi+6+Travel+Router' ),
+    );
+}
+
+function rr_featured_gear_asset( $name, $field = null ) {
+    $assets = rr_featured_gear_assets();
+    $asset  = isset( $assets[ $name ] ) ? $assets[ $name ] : array();
+
+    if ( null === $field ) {
+        return $asset;
+    }
+
+    return isset( $asset[ $field ] ) ? $asset[ $field ] : '';
+}
+
 function rr_blog_topic_term( $slug ) {
     $slug = sanitize_title( $slug );
     return $slug ? get_category_by_slug( $slug ) : false;
@@ -1317,8 +1385,8 @@ function rr_primary_nav_fallback() {
         array( 'url' => home_url('/'),           'label' => 'Home' ),
         array( 'url' => home_url('/start-here'), 'label' => 'Start Here' ),
         array( 'url' => rr_blog_index_url(),     'label' => 'Blog' ),
-        array( 'url' => home_url('/van-life'),   'label' => 'Van Life' ),
-        array( 'url' => home_url('/rv-life'),    'label' => 'RV Life' ),
+        array( 'url' => rr_topic_url( 'van-life' ), 'label' => 'Van Life' ),
+        array( 'url' => rr_topic_url( 'rv-life' ),  'label' => 'RV Life' ),
         array( 'url' => home_url('/gear'),       'label' => 'Gear' ),
         array( 'url' => home_url('/about'),      'label' => 'About Mara' ),
     );
@@ -1340,8 +1408,8 @@ function rr_mobile_nav_fallback() {
         array( 'url' => home_url('/'),           'label' => 'Home' ),
         array( 'url' => home_url('/start-here'), 'label' => 'Start Here' ),
         array( 'url' => rr_blog_index_url(),     'label' => 'Blog', 'submenu' => true ),
-        array( 'url' => home_url('/van-life'),   'label' => 'Van Life' ),
-        array( 'url' => home_url('/rv-life'),    'label' => 'RV Life' ),
+        array( 'url' => rr_topic_url( 'van-life' ), 'label' => 'Van Life' ),
+        array( 'url' => rr_topic_url( 'rv-life' ),  'label' => 'RV Life' ),
         array( 'url' => home_url('/gear'),       'label' => 'Gear' ),
         array( 'url' => home_url('/about'),      'label' => 'About Mara' ),
     );

--- a/page-gear.php
+++ b/page-gear.php
@@ -237,9 +237,14 @@ get_header();
 
             <div class="gear-grid">
                 <?php foreach ( $section['products'] as $product ) :
-                    $shop_url = function_exists( 'rr_affiliate_url' ) ? rr_affiliate_url( $product['shop_url'] ) : $product['shop_url'];
+                    $asset_shop_url = function_exists( 'rr_featured_gear_asset' ) ? rr_featured_gear_asset( $product['name'], 'url' ) : '';
+                    $raw_shop_url   = ! empty( $asset_shop_url ) ? $asset_shop_url : $product['shop_url'];
+                    $shop_url       = function_exists( 'rr_affiliate_url' ) ? rr_affiliate_url( $raw_shop_url ) : $raw_shop_url;
+                    $image_url      = function_exists( 'rr_featured_gear_asset' ) ? rr_featured_gear_asset( $product['name'], 'image' ) : '';
 
                     get_template_part( 'template-parts/affiliate-card', null, array(
+                        'image_url'   => $image_url,
+                        'image_alt'   => $product['name'],
                         'name'        => $product['name'],
                         'verdict'     => $product['verdict'],
                         'stars'       => $product['stars'],


### PR DESCRIPTION
Closes MJM-286

## Acceptance criteria / expected outcome
- Van Life and RV Life navigation must not land on empty WordPress page shells.
- Home gear strip and Gear page product cards must show visible product imagery instead of emoji-only/no-image placeholders.
- Amazon CTAs must keep `tag=rollingreno-20` and use affiliate-safe link attributes.
- Mobile viewport around 390px must have no horizontal overflow and usable card/nav tap targets.

## Changed pages/components/scripts
- Changed pages/components/scripts: `functions.php`, `front-page.php`, `page-gear.php`, `footer.php`, `assets/css/main.css`, `assets/images/gear/*.svg`.
- Changed pages: Home (`/`), Gear (`/gear/`), primary/mobile/footer nav destinations for Van Life/RV Life.

## Staging / preview evidence
- CI preview/regression evidence: GitHub `rolling-reno-regression` check is passing on this PR branch.
- Staging/live bug verification before fix: `/van-life/` and `/rv-life/` returned empty page shells; `/category/van-life/` and `/category/rv-life/` are populated category archives.
- No separate PR deploy preview exists for this WordPress theme PR; evidence is CI + source/static harness before merge, production theme deploy after merge.

## QA evidence
- PHP lint passed: `functions.php`, `front-page.php`, `page-gear.php`, `footer.php`, `template-parts/affiliate-card.php`.
- `git diff --check` passed.
- `npm run test:regression` passed locally after final fixes: 10 passed, 4 skipped.
- Static verification: commit authored by Cian, 12 local SVG gear assets present, Home/Gear call `rr_featured_gear_asset()`, Amazon URLs route through `rr_affiliate_url()`.
- Mobile QA evidence: Sienna 390px harness passed with no horizontal overflow (`390/390`), Home images visible `5/5`, Gear images visible `12/12`, `.gear-card__cta` computed `min-height: 44px` and measured 64px tall.

## Review verdicts
- Aoife UI/UX verdict: PASS. 12/12 Gear products and 5/5 Home featured products map to local SVGs; 390px fixture had no horizontal overflow, 17/17 product images visible, cards fit viewport, and no empty links. Minor non-blocker: Home gear CTA text is compact, but final CSS now gives it a 44px min-height.
- Sienna functional verdict: PASS at commit `524bf48`/latest amended head. Nav/footer/home links route via `rr_topic_url()` to category archives, product imagery wired, Amazon CTAs keep tag/rel attributes, 390px no overflow, CTA tap target fixed.
- Sarah copy QA verdict: PASS. Nav/fallback labels and destinations now match; `Van Life Guides` is used where the destination is the Van Life archive; product names/blurbs/affiliate CTA wording approved.

## Branch freshness / rebase note
- Branch freshness: created from current `origin/main` at `ca67cb6`; latest pushed head has passing CI and local regression after all review fixes.

## Rollback note
- Rollback: revert this PR to restore previous nav URLs and previous Gear/Home card rendering.
