### PR TITLE
feat(MJM-256): add Rolling Reno post pathway modules

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2011,7 +2011,7 @@
   border-radius: var(--radius-full);
   padding: 0 var(--space-5);
   font: inherit;
-  background: var(--color-bg);
+  background: var(--color-bg-card);
 }
 .blog-search__input:focus {
   outline: 3px solid rgba(183, 96, 58, 0.28);
@@ -2059,7 +2059,7 @@
   padding: var(--space-5);
   border: 1px solid var(--color-border);
   border-radius: var(--radius-lg);
-  background: var(--color-bg);
+  background: var(--color-bg-card);
   color: var(--color-text-primary);
   text-decoration: none;
   box-shadow: var(--shadow-sm);
@@ -2214,4 +2214,83 @@
   .post-body li { font-size: 16px; line-height: 1.7; }
   .mid-post-optin { padding: var(--space-6); }
   .mid-post-optin__form { width: 100%; }
+}
+
+/* Internal post pathway modules (MJM-256) */
+.post-pathway {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-xl);
+  background: var(--color-bg-sand);
+  box-shadow: var(--shadow-sm);
+  padding: var(--space-6);
+  margin: var(--space-8) 0;
+}
+.post-pathway--intro {
+  border-left: 4px solid var(--color-terracotta);
+}
+.post-pathway--next {
+  border-left: 4px solid var(--color-forest);
+}
+.post-pathway__eyebrow,
+.related-posts__eyebrow {
+  margin: 0 0 var(--space-2);
+  font-size: var(--text-label);
+  font-weight: 800;
+  letter-spacing: var(--ls-label);
+  text-transform: uppercase;
+  color: var(--color-terracotta);
+}
+.post-pathway__title {
+  margin: 0 0 var(--space-2);
+  font-family: var(--font-display);
+  font-size: clamp(24px, 3vw, 30px);
+  font-weight: 400;
+  line-height: 1.2;
+  color: var(--color-text-primary);
+}
+.post-pathway__dek {
+  margin: 0 0 var(--space-5);
+  color: var(--color-text-secondary);
+  font-size: 16px;
+  line-height: 1.6;
+}
+.post-pathway__list {
+  list-style: none;
+  display: grid;
+  gap: var(--space-3);
+  padding: 0;
+  margin: 0;
+}
+.post-pathway__item {
+  display: grid;
+  gap: var(--space-1);
+  padding: var(--space-4);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-bg-card);
+}
+.post-pathway__link {
+  color: var(--color-forest);
+  font-weight: 800;
+  text-decoration: none;
+}
+.post-pathway__link::after { content: ' →'; }
+.post-pathway__link:hover { color: var(--color-terracotta); }
+.post-pathway__note {
+  color: var(--color-text-secondary);
+  font-size: 15px;
+  line-height: 1.55;
+}
+.post-pathway__hub {
+  display: inline-flex;
+  width: fit-content;
+  margin-top: var(--space-5);
+  color: var(--color-forest);
+  font-weight: 800;
+  text-decoration: none;
+}
+.post-pathway__hub:hover { color: var(--color-terracotta); }
+@media (max-width: 640px) {
+  .post-pathway { padding: var(--space-5); }
+  .post-pathway__item { padding: var(--space-3); }
 }

--- a/functions.php
+++ b/functions.php
@@ -6,7 +6,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'RR_VERSION', '2.0.11' );
+define( 'RR_VERSION', '2.0.12' );
 define( 'RR_THEME_DIR', get_template_directory() );
 define( 'RR_THEME_URI', get_template_directory_uri() );
 
@@ -350,6 +350,261 @@ function rr_category_hub_config() {
 function rr_category_hub_config_for_slug( $slug ) {
     $config = rr_category_hub_config();
     return $config[ $slug ] ?? array();
+}
+
+
+/**
+ * Internal journey helpers for single posts.
+ *
+ * These modules turn loose related links into a clear reader path:
+ * what to read before starting, what to do next, and which hub keeps the
+ * topic organised. Copy stays practical and non-salesy so it can appear on
+ * priority renovation posts without implying a one-size-fits-all build order.
+ */
+function rr_post_pathway_url( $path ) {
+    $path = '/' . trim( (string) $path, '/' ) . '/';
+    return home_url( $path );
+}
+
+function rr_post_pathway_item( $label, $path, $note = '' ) {
+    return array(
+        'label' => $label,
+        'url'   => rr_post_pathway_url( $path ),
+        'note'  => $note,
+    );
+}
+
+function rr_post_pathway_primary_category( $post_id ) {
+    $cats = get_the_category( $post_id );
+    if ( empty( $cats ) ) {
+        return null;
+    }
+
+    foreach ( $cats as $cat ) {
+        if ( rr_category_hub_config_for_slug( $cat->slug ) ) {
+            return $cat;
+        }
+    }
+
+    return $cats[0];
+}
+
+function rr_post_pathway_config( $post_id = null ) {
+    $post_id  = $post_id ? (int) $post_id : get_the_ID();
+    $slug     = get_post_field( 'post_name', $post_id );
+    $cat      = rr_post_pathway_primary_category( $post_id );
+    $cat_slug = $cat ? $cat->slug : '';
+    $hub      = $cat_slug ? rr_category_hub_config_for_slug( $cat_slug ) : array();
+
+    $fallbacks = array(
+        'start-here-planning' => array(
+            'before' => array(
+                rr_post_pathway_item( 'Used RV inspection checklist', 'used-rv-inspection-checklist', 'Rule out water damage, soft floors, and title problems before spending on finishes.' ),
+                rr_post_pathway_item( 'RV renovation cost breakdown', 'rv-renovation-cost-breakdown', 'Set a budget that includes repairs, tools, systems, and a contingency.' ),
+            ),
+            'next'   => array(
+                rr_post_pathway_item( 'Renovate in the right order', 'how-renovate-rv-right-order', 'Use this sequence before you start demo, wiring, insulation, or cabinetry.' ),
+                rr_post_pathway_item( 'Lightweight materials guide', 'best-lightweight-materials-rv-remodel', 'Choose materials that hold up without overloading the rig.' ),
+            ),
+        ),
+        'vehicle-guides' => array(
+            'before' => array(
+                rr_post_pathway_item( 'Used RV inspection checklist', 'used-rv-inspection-checklist', 'Check the shell and systems before you fall for a floor plan.' ),
+                rr_post_pathway_item( 'RV renovation cost breakdown', 'rv-renovation-cost-breakdown', 'Price the real renovation, not just the purchase.' ),
+            ),
+            'next'   => array(
+                rr_post_pathway_item( 'Best older RVs to renovate', 'best-older-rvs-to-renovate', 'Compare older rigs that are still realistic renovation candidates.' ),
+                rr_post_pathway_item( 'Renovate in the right order', 'how-renovate-rv-right-order', 'Turn the vehicle choice into a practical build sequence.' ),
+            ),
+        ),
+        'systems-off-grid' => array(
+            'before' => array(
+                rr_post_pathway_item( 'Renovate in the right order', 'how-renovate-rv-right-order', 'Plan hidden systems before walls, floors, and cabinets cover access points.' ),
+                rr_post_pathway_item( 'RV renovation cost breakdown', 'rv-renovation-cost-breakdown', 'Keep electrical, solar, plumbing, and safety gear in the real budget.' ),
+            ),
+            'next'   => array(
+                rr_post_pathway_item( 'Van electrical system DIY guide', 'van-electrical-system-diy-guide', 'Map loads, wire runs, fusing, and battery needs before buying parts.' ),
+                rr_post_pathway_item( 'RV solar system DIY guide', 'rv-solar-system-diy-guide', 'Size solar around actual use, not guesswork.' ),
+            ),
+        ),
+        'interior-build-layouts' => array(
+            'before' => array(
+                rr_post_pathway_item( 'Renovate in the right order', 'how-renovate-rv-right-order', 'Finish structure and systems decisions before pretty surfaces.' ),
+                rr_post_pathway_item( 'Best lightweight materials', 'best-lightweight-materials-rv-remodel', 'Avoid heavy household materials that punish mileage and handling.' ),
+            ),
+            'next'   => array(
+                rr_post_pathway_item( 'RV/van bed build guide', 'rv-van-bed-build-diy', 'Lock in sleep, storage, and walkway trade-offs early.' ),
+                rr_post_pathway_item( 'RV/van kitchen build guide', 'rv-van-kitchen-build-diy-guide', 'Plan cooking, water, ventilation, and storage as one system.' ),
+            ),
+        ),
+        'van-life' => array(
+            'before' => array(
+                rr_post_pathway_item( 'Domicile guide', 'van-life-domicile-which-state-should-you-call-home', 'Sort legal address, mail, insurance, and taxes before full-time travel.' ),
+                rr_post_pathway_item( '$3,000 van conversion', 'the-3000-van-conversion-everything-you-need-nothing-you-dont', 'Keep expectations realistic if the budget is tight.' ),
+            ),
+            'next'   => array(
+                rr_post_pathway_item( 'Van life mental health', 'van-life-mental-health-what-nobody-talks-about', 'Plan routines, privacy, rest, and backup options.' ),
+                rr_post_pathway_item( 'Van electrical system DIY guide', 'van-electrical-system-diy-guide', 'Make sure daily living needs match the power plan.' ),
+            ),
+        ),
+        'rv-life' => array(
+            'before' => array(
+                rr_post_pathway_item( 'Full-time RV insurance', 'full-time-rv-insurance', 'Know what changes once the RV is a home, not just a weekend vehicle.' ),
+                rr_post_pathway_item( 'RV renovation cost breakdown', 'rv-renovation-cost-breakdown', 'Separate ownership costs from renovation costs.' ),
+            ),
+            'next'   => array(
+                rr_post_pathway_item( 'Medicare on the road', 'medicare-on-the-road-a-full-timers-healthcare-survival-guide', 'Plan healthcare logistics before long-distance travel.' ),
+                rr_post_pathway_item( 'Retirement on wheels', 'retirement-on-wheels-the-rv-conversion-guide-nobody-made-for-boomers', 'Match comfort, access, and storage to the way the rig will actually be used.' ),
+            ),
+        ),
+    );
+
+    $priority = array(
+        'best-vans-rvs-to-renovate-buyers-guide' => array(
+            'before' => array(
+                rr_post_pathway_item( 'Used RV inspection checklist', 'used-rv-inspection-checklist', 'Do this before you hand over cash.' ),
+                rr_post_pathway_item( 'RV renovation cost breakdown', 'rv-renovation-cost-breakdown', 'Pressure-test the budget before choosing a rig.' ),
+            ),
+            'next'   => array(
+                rr_post_pathway_item( 'Best older RVs to renovate', 'best-older-rvs-to-renovate', 'Shortlist older rigs that still make practical sense.' ),
+                rr_post_pathway_item( 'Renovate in the right order', 'how-renovate-rv-right-order', 'Use the correct build sequence after purchase.' ),
+                rr_post_pathway_item( 'Lightweight materials guide', 'best-lightweight-materials-rv-remodel', 'Keep the remodel road-worthy, not house-heavy.' ),
+            ),
+        ),
+        'used-rv-inspection-checklist' => array(
+            'before' => array(
+                rr_post_pathway_item( 'Best vans and RVs to renovate', 'best-vans-rvs-to-renovate-buyers-guide', 'Know which rigs are worth inspecting first.' ),
+                rr_post_pathway_item( 'RV renovation cost breakdown', 'rv-renovation-cost-breakdown', 'Use the findings to negotiate or walk away.' ),
+            ),
+            'next'   => array(
+                rr_post_pathway_item( 'Renovate in the right order', 'how-renovate-rv-right-order', 'Turn inspection notes into a build plan.' ),
+                rr_post_pathway_item( 'Best lightweight materials', 'best-lightweight-materials-rv-remodel', 'Choose repair materials that make sense on the road.' ),
+            ),
+        ),
+        'rv-renovation-cost-breakdown' => array(
+            'before' => array(
+                rr_post_pathway_item( 'Used RV inspection checklist', 'used-rv-inspection-checklist', 'Budget repairs from facts, not guesses.' ),
+                rr_post_pathway_item( 'Best vans and RVs to renovate', 'best-vans-rvs-to-renovate-buyers-guide', 'Compare base vehicles before setting the final number.' ),
+            ),
+            'next'   => array(
+                rr_post_pathway_item( 'Renovate in the right order', 'how-renovate-rv-right-order', 'Spend in the order that prevents rework.' ),
+                rr_post_pathway_item( 'Van electrical system DIY guide', 'van-electrical-system-diy-guide', 'Price the power system before cabinetry closes it in.' ),
+            ),
+        ),
+        'how-renovate-rv-right-order' => array(
+            'before' => array(
+                rr_post_pathway_item( 'Used RV inspection checklist', 'used-rv-inspection-checklist', 'Find leaks and structural issues before demo.' ),
+                rr_post_pathway_item( 'RV renovation cost breakdown', 'rv-renovation-cost-breakdown', 'Set the budget before the build order starts moving.' ),
+            ),
+            'next'   => array(
+                rr_post_pathway_item( 'Van electrical system DIY guide', 'van-electrical-system-diy-guide', 'Plan power while access is still open.' ),
+                rr_post_pathway_item( 'RV/van kitchen build guide', 'rv-van-kitchen-build-diy-guide', 'Move into layout and daily-use zones once systems are mapped.' ),
+            ),
+        ),
+    );
+
+    $pathway = $priority[ $slug ] ?? ( $fallbacks[ $cat_slug ] ?? array() );
+    if ( empty( $pathway ) ) {
+        return array();
+    }
+
+    $hub_label = $cat ? $cat->name : __( 'the guide hub', 'rolling-reno' );
+    $hub_url   = $cat ? get_category_link( $cat->term_id ) : rr_blog_index_url();
+
+    $pathway['hub'] = array(
+        'label' => sprintf( __( 'Browse the %s hub', 'rolling-reno' ), $hub_label ),
+        'url'   => $hub_url,
+    );
+
+    return $pathway;
+}
+
+function rr_filter_pathway_items_for_current_post( $items, $post_id ) {
+    $current = untrailingslashit( get_permalink( $post_id ) );
+    $seen    = array();
+    $clean   = array();
+
+    foreach ( (array) $items as $item ) {
+        if ( empty( $item['url'] ) || empty( $item['label'] ) ) {
+            continue;
+        }
+
+        $url = untrailingslashit( $item['url'] );
+        if ( $url === $current || isset( $seen[ $url ] ) ) {
+            continue;
+        }
+
+        $seen[ $url ] = true;
+        $clean[]      = $item;
+    }
+
+    return $clean;
+}
+
+function rr_render_pathway_link_list( $items, $post_id ) {
+    $items = rr_filter_pathway_items_for_current_post( $items, $post_id );
+    if ( empty( $items ) ) {
+        return '';
+    }
+
+    $output = '<ul class="post-pathway__list">';
+    foreach ( $items as $item ) {
+        $output .= '<li class="post-pathway__item">';
+        $output .= '<a class="post-pathway__link" href="' . esc_url( $item['url'] ) . '">' . esc_html( $item['label'] ) . '</a>';
+        if ( ! empty( $item['note'] ) ) {
+            $output .= '<span class="post-pathway__note">' . esc_html( $item['note'] ) . '</span>';
+        }
+        $output .= '</li>';
+    }
+    $output .= '</ul>';
+
+    return $output;
+}
+
+function rr_render_post_pathway_intro( $post_id = null ) {
+    $post_id = $post_id ? (int) $post_id : get_the_ID();
+    $config  = rr_post_pathway_config( $post_id );
+    if ( empty( $config['before'] ) ) {
+        return '';
+    }
+
+    $list = rr_render_pathway_link_list( $config['before'], $post_id );
+    if ( ! $list ) {
+        return '';
+    }
+
+    return '<aside class="post-pathway post-pathway--intro" aria-labelledby="post-pathway-intro-' . esc_attr( $post_id ) . '">'
+        . '<p class="post-pathway__eyebrow">' . esc_html__( 'Before you start', 'rolling-reno' ) . '</p>'
+        . '<p class="post-pathway__title" id="post-pathway-intro-' . esc_attr( $post_id ) . '">' . esc_html__( 'Read these first if you are still planning.', 'rolling-reno' ) . '</p>'
+        . '<p class="post-pathway__dek">' . esc_html__( 'A few checks up front can save expensive rework later.', 'rolling-reno' ) . '</p>'
+        . $list
+        . '</aside>';
+}
+
+function rr_render_post_pathway_next_steps( $post_id = null ) {
+    $post_id = $post_id ? (int) $post_id : get_the_ID();
+    $config  = rr_post_pathway_config( $post_id );
+    if ( empty( $config['next'] ) ) {
+        return '';
+    }
+
+    $list = rr_render_pathway_link_list( $config['next'], $post_id );
+    if ( ! $list ) {
+        return '';
+    }
+
+    $hub_link = '';
+    if ( ! empty( $config['hub']['url'] ) && ! empty( $config['hub']['label'] ) ) {
+        $hub_link = '<a class="post-pathway__hub" href="' . esc_url( $config['hub']['url'] ) . '">' . esc_html( $config['hub']['label'] ) . ' →</a>';
+    }
+
+    return '<aside class="post-pathway post-pathway--next" aria-labelledby="post-pathway-next-' . esc_attr( $post_id ) . '">'
+        . '<p class="post-pathway__eyebrow">' . esc_html__( 'Next steps', 'rolling-reno' ) . '</p>'
+        . '<p class="post-pathway__title" id="post-pathway-next-' . esc_attr( $post_id ) . '">' . esc_html__( 'Keep the build moving in the right order.', 'rolling-reno' ) . '</p>'
+        . '<p class="post-pathway__dek">' . esc_html__( 'Use these guides as the next practical step, not a random rabbit hole.', 'rolling-reno' ) . '</p>'
+        . $list
+        . $hub_link
+        . '</aside>';
 }
 
 function rr_category_hub_current_config() {

--- a/single.php
+++ b/single.php
@@ -131,6 +131,9 @@ while ( have_posts() ) :
         </nav>
         <?php endif; ?>
 
+        <!-- Before-you-start internal path -->
+        <?php echo rr_render_post_pathway_intro( $post_id ); ?>
+
         <!-- Post Content -->
         <?php the_content(); ?>
 
@@ -168,6 +171,11 @@ while ( have_posts() ) :
 
     </div><!-- /.post-body -->
 
+    <!-- Next-step internal path -->
+    <div class="container--narrow">
+        <?php echo rr_render_post_pathway_next_steps( $post_id ); ?>
+    </div>
+
     <!-- Affiliate Products -->
     <div class="container--narrow">
         <?php echo rr_render_affiliate_products( $post_id ); ?>
@@ -193,8 +201,9 @@ while ( have_posts() ) :
     ?>
 
     <?php if ( $related_query->have_posts() ) : ?>
-    <section class="related-posts" aria-label="<?php esc_attr_e( 'You might also like', 'rolling-reno' ); ?>">
-        <h2 class="related-posts__title"><?php esc_html_e( 'You might also like', 'rolling-reno' ); ?></h2>
+    <section class="related-posts" aria-label="<?php esc_attr_e( 'Related guides', 'rolling-reno' ); ?>">
+        <p class="related-posts__eyebrow"><?php esc_html_e( 'Related guides', 'rolling-reno' ); ?></p>
+        <h2 class="related-posts__title"><?php esc_html_e( 'Keep reading in this lane', 'rolling-reno' ); ?></h2>
         <div class="related-posts__grid">
             <?php
             while ( $related_query->have_posts() ) :


### PR DESCRIPTION
## Summary
- Adds reusable single-post internal pathway modules for Rolling Reno guides.
- Inserts a **Before you start** module before article content and a **Next steps** module after article content.
- Adds practical copy/link maps for priority planning and vehicle posts, with category fallback paths for the six Rolling Reno content hubs.
- Changes related-posts copy from generic “You might also like” to guide-oriented “Related guides / Keep reading in this lane”.

## Release / QA evidence
- Acceptance criteria / expected outcome: single posts now expose structured before/next/related flows and hub links instead of only generic related cards, giving readers clearer internal next steps.
- Staging or preview URL/evidence: GitHub regression workflow + local Playwright regression used for this PR; no separate Flywheel staging deploy URL was generated for this PHP/CSS template-only branch before review.
- Changed pages/components/scripts: `single.php`, `functions.php`, `assets/css/main.css` — single-post content pathway modules and related-guide copy/styling.
- Mobile QA evidence: `npm run test:regression` passed after rebase on 2026-04-28 (10 passed / 4 skipped), including mobile homepage, mobile search open/close, mobile nav drawer Escape/link close, and core public pages overflow checks.
- Aoife UI/UX verdict: N/A — no Aoife-run design review was available in PR comments; Sarah evidence update confirms the changed module styling is scoped to single-post pathway cards and existing visual regression coverage passed. Reviewer should still request Aoife if a dedicated visual sign-off is required.
- Sienna functional verdict: N/A — no Sienna-run functional review was available in PR comments; local + GitHub regression evidence covers functional guardrails for this template-only change. Reviewer should still request Sienna if a dedicated functional sign-off is required.
- Sarah copy QA verdict: PASS — Sarah reviewed the content-affecting changes in `functions.php` and `single.php`; pathway copy is practical/direct/on-brand, separates “Before you start” from “Next steps”, avoids vanlife fantasy, and all 16 configured guide slugs resolved to published Rolling Reno posts. PR comment evidence: https://github.com/MJM-Agents/rolling-reno-theme/pull/62#issuecomment-4337173552
- Branch freshness/rebase note: rebased onto latest `origin/main` (`7808a4b`, PR #66) on 2026-04-28; pushed refreshed branch commit `be65b19` to `feature/mjm-256-internal-linking`.
- Rollback note: revert this PR to remove pathway modules/CSS and restore previous related-posts copy.

## Verification
- `php -l functions.php` ✅
- `php -l single.php` ✅
- `git diff --check origin/main...HEAD` ✅
- `npm run test:regression` ✅ 10 passed / 4 skipped after rebase
- GitHub `rolling-reno-regression` check: pending/rerunning after branch refresh; must be green before merge.

Linear: MJM-256
