### PR TITLE
fix: build deploy Slack JSON safely

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -93,9 +93,20 @@ jobs:
           ACTOR="${{ github.actor }}"
           STATUS="${{ job.status }}"
           EMOJI=$([ "$STATUS" = "success" ] && echo "✅" || echo "❌")
-          MESSAGE="$EMOJI *Rolling Reno Staging Deploy* - \`$BRANCH\` (\`$SHORT_SHA\`) by $ACTOR\nStatus: $STATUS\nStaging URL: <${{ env.STAGING_URL }}|rollingreno.flywheelstaging.com>\n_Aoife + Sienna: please review and comment on the PR before merge to main._"
+          printf -v MESSAGE '%s *Rolling Reno Staging Deploy* - `%s` (`%s`) by %s\nStatus: %s\nStaging URL: <%s|rollingreno.flywheelstaging.com>\n_Aoife + Sienna: please review and comment on the PR before merge to main._' \
+            "$EMOJI" \
+            "$BRANCH" \
+            "$SHORT_SHA" \
+            "$ACTOR" \
+            "$STATUS" \
+            "${{ env.STAGING_URL }}"
+          PAYLOAD=$(jq -n \
+            --arg channel "C0AQLB1JXBL" \
+            --arg text "$MESSAGE" \
+            '{channel: $channel, text: $text}')
+
           curl -s -X POST \
             -H "Authorization: Bearer ${{ secrets.SLACK_BOT_TOKEN }}" \
             -H "Content-Type: application/json" \
-            --data "{\"channel\":\"C0AQLB1JXBL\",\"text\":\"$MESSAGE\"}" \
+            --data "$PAYLOAD" \
             https://slack.com/api/chat.postMessage | jq -r '.ok'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,13 +25,22 @@ jobs:
       - name: Notify Slack - deploy starting
         if: always()
         run: |
+          printf -v MESSAGE '🚀 *Deploy starting* - `%s` → production\nCommit: `%s` by %s\nRun: <%s/%s/actions/runs/%s|View>' \
+            "rolling-reno-v2" \
+            "${GITHUB_SHA::7}" \
+            "${GITHUB_ACTOR}" \
+            "${{ github.server_url }}" \
+            "${{ github.repository }}" \
+            "${{ github.run_id }}"
+          PAYLOAD=$(jq -n \
+            --arg channel "C0AQLB1JXBL" \
+            --arg text "$MESSAGE" \
+            '{channel: $channel, text: $text}')
+
           curl -sf -X POST https://slack.com/api/chat.postMessage \
             -H "Authorization: Bearer ${{ secrets.SLACK_BOT_TOKEN }}" \
             -H "Content-Type: application/json" \
-            -d "{
-              \"channel\": \"C0AQLB1JXBL\",
-              \"text\": \"🚀 *Deploy starting* - \\`rolling-reno-v2\\` → production\nCommit: \\`${GITHUB_SHA::7}\\` by ${GITHUB_ACTOR}\nRun: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View>\"
-            }" || true
+            --data "$PAYLOAD" || true
 
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -237,21 +246,40 @@ jobs:
             SMOKE_STATUS=" ✅ Smoke test passed"
           fi
 
+          printf -v MESSAGE '✅ *Deploy complete* - `%s` → production\nCommit: `%s` by %s%s\nRun: <%s/%s/actions/runs/%s|View>' \
+            "rolling-reno-v2" \
+            "${GITHUB_SHA::7}" \
+            "${GITHUB_ACTOR}" \
+            "${SMOKE_STATUS}" \
+            "${{ github.server_url }}" \
+            "${{ github.repository }}" \
+            "${{ github.run_id }}"
+          PAYLOAD=$(jq -n \
+            --arg channel "C0AQLB1JXBL" \
+            --arg text "$MESSAGE" \
+            '{channel: $channel, text: $text}')
+
           curl -sf -X POST https://slack.com/api/chat.postMessage \
             -H "Authorization: Bearer ${{ secrets.SLACK_BOT_TOKEN }}" \
             -H "Content-Type: application/json" \
-            -d "{
-              \"channel\": \"C0AQLB1JXBL\",
-              \"text\": \"✅ *Deploy complete* - \\`rolling-reno-v2\\` → production\nCommit: \\`${GITHUB_SHA::7}\\` by ${GITHUB_ACTOR}${SMOKE_STATUS}\nRun: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View>\"
-            }" || true
+            --data "$PAYLOAD" || true
 
       - name: Notify Slack - deploy failed
         if: failure()
         run: |
+          printf -v MESSAGE '❌ *Deploy FAILED* - `%s` → production\nCommit: `%s` by %s\nRun: <%s/%s/actions/runs/%s|View>' \
+            "rolling-reno-v2" \
+            "${GITHUB_SHA::7}" \
+            "${GITHUB_ACTOR}" \
+            "${{ github.server_url }}" \
+            "${{ github.repository }}" \
+            "${{ github.run_id }}"
+          PAYLOAD=$(jq -n \
+            --arg channel "C0AQLB1JXBL" \
+            --arg text "$MESSAGE" \
+            '{channel: $channel, text: $text}')
+
           curl -sf -X POST https://slack.com/api/chat.postMessage \
             -H "Authorization: Bearer ${{ secrets.SLACK_BOT_TOKEN }}" \
             -H "Content-Type: application/json" \
-            -d "{
-              \"channel\": \"C0AQLB1JXBL\",
-              \"text\": \"❌ *Deploy FAILED* - \\`rolling-reno-v2\\` → production\nCommit: \\`${GITHUB_SHA::7}\\` by ${GITHUB_ACTOR}\nRun: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View>\"
-            }" || true
+            --data "$PAYLOAD" || true


### PR DESCRIPTION
## Summary
- Replaced inline Slack JSON strings in production deploy start/complete/failure notifications with `printf -v` message construction plus `jq -n` JSON payload generation.
- Updated staging deploy completion notification to use the same safe `jq -n` payload path.
- Removes shell command-substitution risk from Slack backtick formatting while preserving Slack newlines and message formatting.

Closes #63.
Linear: MJM-239

## Acceptance criteria / expected outcome
- Deploy Slack notification payloads are valid JSON for production start, production success, production failure, and staging deploy completion.
- Slack backtick formatting no longer triggers shell command substitution while constructing JSON.
- Existing deploy behavior is unchanged; only notification payload construction changes.

## Changed pages/components/scripts
- `.github/workflows/deploy.yml`
- `.github/workflows/deploy-staging.yml`
- No theme runtime files, WordPress templates, CSS, JS, content, or public pages changed.

## Validation
- GitHub regression check: passing on PR #66.
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/deploy.yml"); YAML.load_file(".github/workflows/deploy-staging.yml"); puts "YAML OK"'`
- `bash -n /tmp/rr-gh63-validate.sh && bash /tmp/rr-gh63-validate.sh`
  - Confirmed generated payloads are valid JSON for production start, production complete, production failure, and staging complete.
  - Confirmed payload text contains Slack backticks and newline text without shell command substitution.
- `grep -R --line-number -- '-d "{' .github/workflows/deploy.yml .github/workflows/deploy-staging.yml || true`
- `grep -R --line-number -- '--data "{\"channel' .github/workflows/deploy.yml .github/workflows/deploy-staging.yml || true`

## Release / QA notes
- Staging URL: N/A — GitHub Actions workflow notification-only hotfix; no site-facing runtime code changed.
- Aoife UI/UX verdict: N/A — no public UI changed.
- Sienna functional verdict: N/A — no WordPress runtime behavior changed; CI regression passed and notification payload generation was validated locally.
- Sarah copy QA verdict: N/A — operational Slack deploy messages only; no public copy/content changed.
- Branch freshness/rebase note: branch `conor/gh63-deploy-slack-json` is mergeable into `main`; GitHub reports `MERGEABLE`; regression check passed after latest main deploy workflow base.

## Rollback
- Revert this PR to restore previous deploy notification command construction.
