### PR TITLE
fix(MJM-239): harden deploy Slack notification JSON

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -94,8 +94,13 @@ jobs:
           STATUS="${{ job.status }}"
           EMOJI=$([ "$STATUS" = "success" ] && echo "✅" || echo "❌")
           MESSAGE="$EMOJI *Rolling Reno Staging Deploy* - \`$BRANCH\` (\`$SHORT_SHA\`) by $ACTOR\nStatus: $STATUS\nStaging URL: <${{ env.STAGING_URL }}|rollingreno.flywheelstaging.com>\n_Aoife + Sienna: please review and comment on the PR before merge to main._"
+          payload=$(jq -n \
+            --arg channel "C0AQLB1JXBL" \
+            --arg text "$MESSAGE" \
+            '{channel: $channel, text: $text}')
+
           curl -s -X POST \
             -H "Authorization: Bearer ${{ secrets.SLACK_BOT_TOKEN }}" \
-            -H "Content-Type: application/json" \
-            --data "{\"channel\":\"C0AQLB1JXBL\",\"text\":\"$MESSAGE\"}" \
+            -H "Content-Type: application/json; charset=utf-8" \
+            --data "$payload" \
             https://slack.com/api/chat.postMessage | jq -r '.ok'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,13 +25,15 @@ jobs:
       - name: Notify Slack - deploy starting
         if: always()
         run: |
+          payload=$(jq -n \
+            --arg channel "C0AQLB1JXBL" \
+            --arg text "🚀 *Deploy starting* - \`rolling-reno-v2\` → production\nCommit: \`${GITHUB_SHA::7}\` by ${GITHUB_ACTOR}\nRun: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View>" \
+            '{channel: $channel, text: $text}')
+
           curl -sf -X POST https://slack.com/api/chat.postMessage \
             -H "Authorization: Bearer ${{ secrets.SLACK_BOT_TOKEN }}" \
-            -H "Content-Type: application/json" \
-            -d "{
-              \"channel\": \"C0AQLB1JXBL\",
-              \"text\": \"🚀 *Deploy starting* - \\`rolling-reno-v2\\` → production\nCommit: \\`${GITHUB_SHA::7}\\` by ${GITHUB_ACTOR}\nRun: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View>\"
-            }" || true
+            -H "Content-Type: application/json; charset=utf-8" \
+            --data "$payload" || true
 
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -237,21 +239,25 @@ jobs:
             SMOKE_STATUS=" ✅ Smoke test passed"
           fi
 
+          payload=$(jq -n \
+            --arg channel "C0AQLB1JXBL" \
+            --arg text "✅ *Deploy complete* - \`rolling-reno-v2\` → production\nCommit: \`${GITHUB_SHA::7}\` by ${GITHUB_ACTOR}${SMOKE_STATUS}\nRun: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View>" \
+            '{channel: $channel, text: $text}')
+
           curl -sf -X POST https://slack.com/api/chat.postMessage \
             -H "Authorization: Bearer ${{ secrets.SLACK_BOT_TOKEN }}" \
-            -H "Content-Type: application/json" \
-            -d "{
-              \"channel\": \"C0AQLB1JXBL\",
-              \"text\": \"✅ *Deploy complete* - \\`rolling-reno-v2\\` → production\nCommit: \\`${GITHUB_SHA::7}\\` by ${GITHUB_ACTOR}${SMOKE_STATUS}\nRun: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View>\"
-            }" || true
+            -H "Content-Type: application/json; charset=utf-8" \
+            --data "$payload" || true
 
       - name: Notify Slack - deploy failed
         if: failure()
         run: |
+          payload=$(jq -n \
+            --arg channel "C0AQLB1JXBL" \
+            --arg text "❌ *Deploy FAILED* - \`rolling-reno-v2\` → production\nCommit: \`${GITHUB_SHA::7}\` by ${GITHUB_ACTOR}\nRun: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View>" \
+            '{channel: $channel, text: $text}')
+
           curl -sf -X POST https://slack.com/api/chat.postMessage \
             -H "Authorization: Bearer ${{ secrets.SLACK_BOT_TOKEN }}" \
-            -H "Content-Type: application/json" \
-            -d "{
-              \"channel\": \"C0AQLB1JXBL\",
-              \"text\": \"❌ *Deploy FAILED* - \\`rolling-reno-v2\\` → production\nCommit: \\`${GITHUB_SHA::7}\\` by ${GITHUB_ACTOR}\nRun: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View>\"
-            }" || true
+            -H "Content-Type: application/json; charset=utf-8" \
+            --data "$payload" || true


### PR DESCRIPTION
## Summary
- Builds production deploy Slack payloads with `jq -n` instead of inline JSON strings
- Applies the same safe payload construction to staging deploy notifications
- Adds charset on Slack JSON requests

## Why
The production deploy succeeded, but the Slack completion step emitted `invalid_json` because Slack backtick formatting was interpreted by the shell while building JSON.

## Verification
- `ruby -e 'require "yaml"; ...'` YAML parse for deploy workflows\n- `bash -n` on modified notification run blocks after replacing GitHub expressions\n- Representative `jq -n` payload generation with backticks/newlines validates via `jq -e`\n- `git diff --check`\n\n## Release QA\n- Staging URL: N/A — CI/deploy workflow notification-only change\n- Changed components: `.github/workflows/deploy.yml`, `.github/workflows/deploy-staging.yml`\n- Aoife visual QA: N/A\n- Sienna functional QA: N/A until workflow run; syntax/payload checks passed locally\n- Sarah copy QA: N/A\n- Rollback: revert this PR to restore prior notification construction\n\nCloses MJM-239. Related fallback issue: #63.