### PR TITLE
fix: harden deploy Slack JSON payloads

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -93,9 +93,11 @@ jobs:
           ACTOR="${{ github.actor }}"
           STATUS="${{ job.status }}"
           EMOJI=$([ "$STATUS" = "success" ] && echo "✅" || echo "❌")
-          MESSAGE="$EMOJI *Rolling Reno Staging Deploy* - \`$BRANCH\` (\`$SHORT_SHA\`) by $ACTOR\nStatus: $STATUS\nStaging URL: <${{ env.STAGING_URL }}|rollingreno.flywheelstaging.com>\n_Aoife + Sienna: please review and comment on the PR before merge to main._"
+          MESSAGE=$(printf '%s *Rolling Reno Staging Deploy* - `%s` (`%s`) by %s\nStatus: %s\nStaging URL: <%s|rollingreno.flywheelstaging.com>\n_Aoife + Sienna: please review and comment on the PR before merge to main._' "$EMOJI" "$BRANCH" "$SHORT_SHA" "$ACTOR" "$STATUS" "${{ env.STAGING_URL }}")
+          PAYLOAD=$(jq -n --arg channel "C0AQLB1JXBL" --arg text "$MESSAGE" '{channel: $channel, text: $text}')
+
           curl -s -X POST \
             -H "Authorization: Bearer ${{ secrets.SLACK_BOT_TOKEN }}" \
-            -H "Content-Type: application/json" \
-            --data "{\"channel\":\"C0AQLB1JXBL\",\"text\":\"$MESSAGE\"}" \
+            -H "Content-Type: application/json; charset=utf-8" \
+            --data "$PAYLOAD" \
             https://slack.com/api/chat.postMessage | jq -r '.ok'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,13 +25,15 @@ jobs:
       - name: Notify Slack - deploy starting
         if: always()
         run: |
+          SHORT_SHA="${GITHUB_SHA::7}"
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          MESSAGE=$(printf '🚀 *Deploy starting* - `rolling-reno-v2` → production\nCommit: `%s` by %s\nRun: <%s|View>' "$SHORT_SHA" "$GITHUB_ACTOR" "$RUN_URL")
+          PAYLOAD=$(jq -n --arg channel "C0AQLB1JXBL" --arg text "$MESSAGE" '{channel: $channel, text: $text}')
+
           curl -sf -X POST https://slack.com/api/chat.postMessage \
             -H "Authorization: Bearer ${{ secrets.SLACK_BOT_TOKEN }}" \
-            -H "Content-Type: application/json" \
-            -d "{
-              \"channel\": \"C0AQLB1JXBL\",
-              \"text\": \"🚀 *Deploy starting* - \\`rolling-reno-v2\\` → production\nCommit: \\`${GITHUB_SHA::7}\\` by ${GITHUB_ACTOR}\nRun: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View>\"
-            }" || true
+            -H "Content-Type: application/json; charset=utf-8" \
+            --data "$PAYLOAD" || true
 
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -237,21 +239,25 @@ jobs:
             SMOKE_STATUS=" ✅ Smoke test passed"
           fi
 
+          SHORT_SHA="${GITHUB_SHA::7}"
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          MESSAGE=$(printf '✅ *Deploy complete* - `rolling-reno-v2` → production\nCommit: `%s` by %s%s\nRun: <%s|View>' "$SHORT_SHA" "$GITHUB_ACTOR" "$SMOKE_STATUS" "$RUN_URL")
+          PAYLOAD=$(jq -n --arg channel "C0AQLB1JXBL" --arg text "$MESSAGE" '{channel: $channel, text: $text}')
+
           curl -sf -X POST https://slack.com/api/chat.postMessage \
             -H "Authorization: Bearer ${{ secrets.SLACK_BOT_TOKEN }}" \
-            -H "Content-Type: application/json" \
-            -d "{
-              \"channel\": \"C0AQLB1JXBL\",
-              \"text\": \"✅ *Deploy complete* - \\`rolling-reno-v2\\` → production\nCommit: \\`${GITHUB_SHA::7}\\` by ${GITHUB_ACTOR}${SMOKE_STATUS}\nRun: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View>\"
-            }" || true
+            -H "Content-Type: application/json; charset=utf-8" \
+            --data "$PAYLOAD" || true
 
       - name: Notify Slack - deploy failed
         if: failure()
         run: |
+          SHORT_SHA="${GITHUB_SHA::7}"
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          MESSAGE=$(printf '❌ *Deploy FAILED* - `rolling-reno-v2` → production\nCommit: `%s` by %s\nRun: <%s|View>' "$SHORT_SHA" "$GITHUB_ACTOR" "$RUN_URL")
+          PAYLOAD=$(jq -n --arg channel "C0AQLB1JXBL" --arg text "$MESSAGE" '{channel: $channel, text: $text}')
+
           curl -sf -X POST https://slack.com/api/chat.postMessage \
             -H "Authorization: Bearer ${{ secrets.SLACK_BOT_TOKEN }}" \
-            -H "Content-Type: application/json" \
-            -d "{
-              \"channel\": \"C0AQLB1JXBL\",
-              \"text\": \"❌ *Deploy FAILED* - \\`rolling-reno-v2\\` → production\nCommit: \\`${GITHUB_SHA::7}\\` by ${GITHUB_ACTOR}\nRun: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View>\"
-            }" || true
+            -H "Content-Type: application/json; charset=utf-8" \
+            --data "$PAYLOAD" || true


### PR DESCRIPTION
## Summary
- Fixes deploy Slack notification payload construction for production deploy start/success/failure messages.
- Fixes staging deploy Slack payload construction too, since it used the same fragile inline JSON pattern.
- Replaces hand-built JSON strings with `jq -n --arg ...` payload generation so newlines, backticks, emoji, arrows, actors, and run URLs are JSON-escaped correctly.

## Ticket
MJM-239 — Rolling Reno — deploy Slack notification JSON hotfix

## Release evidence
- Changed pages/components: GitHub Actions deploy workflows only (`.github/workflows/deploy.yml`, `.github/workflows/deploy-staging.yml`). No theme runtime files changed.
- Acceptance criteria: deploy notification payloads are valid JSON and continue to post to `C0AQLB1JXBL` via Slack `chat.postMessage`.
- Validation run locally:
  - Ruby YAML parse passed for both workflow files.
  - Local `jq` payload smoke test passed for multiline Slack text including emoji, backticks, actor, smoke status, and run URL.
  - `git diff --check` clean.
  - Confirmed old inline `--data "{\"channel\"...` / `-d "{` payload patterns are gone.
- Staging URL: N/A — workflow-only Slack payload hotfix; no site-facing code changes.
- Aoife/Sienna QA: N/A — no UI/functional site runtime change.
- Sarah copy QA: N/A — operational Slack deploy message only, no public copy change.
- Branch freshness: branched from `origin/main` at `5bab552` on 2026-04-28.

## Rollback
Revert commit `2787e1b` to restore the previous deploy workflow notification blocks.
