### PR TITLE
fix(MJM-239): build Slack deploy payloads with jq

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -93,9 +93,10 @@ jobs:
           ACTOR="${{ github.actor }}"
           STATUS="${{ job.status }}"
           EMOJI=$([ "$STATUS" = "success" ] && echo "✅" || echo "❌")
-          MESSAGE="$EMOJI *Rolling Reno Staging Deploy* - \`$BRANCH\` (\`$SHORT_SHA\`) by $ACTOR\nStatus: $STATUS\nStaging URL: <${{ env.STAGING_URL }}|rollingreno.flywheelstaging.com>\n_Aoife + Sienna: please review and comment on the PR before merge to main._"
-          curl -s -X POST \
-            -H "Authorization: Bearer ${{ secrets.SLACK_BOT_TOKEN }}" \
-            -H "Content-Type: application/json" \
-            --data "{\"channel\":\"C0AQLB1JXBL\",\"text\":\"$MESSAGE\"}" \
-            https://slack.com/api/chat.postMessage | jq -r '.ok'
+          MESSAGE=$(printf '%s *Rolling Reno Staging Deploy* - `%s` (`%s`) by %s\nStatus: %s\nStaging URL: <%s|rollingreno.flywheelstaging.com>\n_Aoife + Sienna: please review and comment on the PR before merge to main._' "$EMOJI" "$BRANCH" "$SHORT_SHA" "$ACTOR" "$STATUS" "${{ env.STAGING_URL }}")
+          jq -n --arg channel "C0AQLB1JXBL" --arg text "$MESSAGE" \
+            '{channel: $channel, text: $text}' \
+            | curl -s -X POST https://slack.com/api/chat.postMessage \
+                -H "Authorization: Bearer ${{ secrets.SLACK_BOT_TOKEN }}" \
+                -H "Content-Type: application/json" \
+                --data-binary @- | jq -r '.ok'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,13 +25,14 @@ jobs:
       - name: Notify Slack - deploy starting
         if: always()
         run: |
-          curl -sf -X POST https://slack.com/api/chat.postMessage \
-            -H "Authorization: Bearer ${{ secrets.SLACK_BOT_TOKEN }}" \
-            -H "Content-Type: application/json" \
-            -d "{
-              \"channel\": \"C0AQLB1JXBL\",
-              \"text\": \"🚀 *Deploy starting* - \\`rolling-reno-v2\\` → production\nCommit: \\`${GITHUB_SHA::7}\\` by ${GITHUB_ACTOR}\nRun: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View>\"
-            }" || true
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          MESSAGE=$(printf '🚀 *Deploy starting* - `rolling-reno-v2` → production\nCommit: `%s` by %s\nRun: <%s|View>' "${GITHUB_SHA::7}" "$GITHUB_ACTOR" "$RUN_URL")
+          jq -n --arg channel "C0AQLB1JXBL" --arg text "$MESSAGE" \
+            '{channel: $channel, text: $text}' \
+            | curl -sf -X POST https://slack.com/api/chat.postMessage \
+                -H "Authorization: Bearer ${{ secrets.SLACK_BOT_TOKEN }}" \
+                -H "Content-Type: application/json" \
+                --data-binary @- || true
 
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -237,21 +238,23 @@ jobs:
             SMOKE_STATUS=" ✅ Smoke test passed"
           fi
 
-          curl -sf -X POST https://slack.com/api/chat.postMessage \
-            -H "Authorization: Bearer ${{ secrets.SLACK_BOT_TOKEN }}" \
-            -H "Content-Type: application/json" \
-            -d "{
-              \"channel\": \"C0AQLB1JXBL\",
-              \"text\": \"✅ *Deploy complete* - \\`rolling-reno-v2\\` → production\nCommit: \\`${GITHUB_SHA::7}\\` by ${GITHUB_ACTOR}${SMOKE_STATUS}\nRun: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View>\"
-            }" || true
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          MESSAGE=$(printf '✅ *Deploy complete* - `rolling-reno-v2` → production\nCommit: `%s` by %s%s\nRun: <%s|View>' "${GITHUB_SHA::7}" "$GITHUB_ACTOR" "$SMOKE_STATUS" "$RUN_URL")
+          jq -n --arg channel "C0AQLB1JXBL" --arg text "$MESSAGE" \
+            '{channel: $channel, text: $text}' \
+            | curl -sf -X POST https://slack.com/api/chat.postMessage \
+                -H "Authorization: Bearer ${{ secrets.SLACK_BOT_TOKEN }}" \
+                -H "Content-Type: application/json" \
+                --data-binary @- || true
 
       - name: Notify Slack - deploy failed
         if: failure()
         run: |
-          curl -sf -X POST https://slack.com/api/chat.postMessage \
-            -H "Authorization: Bearer ${{ secrets.SLACK_BOT_TOKEN }}" \
-            -H "Content-Type: application/json" \
-            -d "{
-              \"channel\": \"C0AQLB1JXBL\",
-              \"text\": \"❌ *Deploy FAILED* - \\`rolling-reno-v2\\` → production\nCommit: \\`${GITHUB_SHA::7}\\` by ${GITHUB_ACTOR}\nRun: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View>\"
-            }" || true
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          MESSAGE=$(printf '❌ *Deploy FAILED* - `rolling-reno-v2` → production\nCommit: `%s` by %s\nRun: <%s|View>' "${GITHUB_SHA::7}" "$GITHUB_ACTOR" "$RUN_URL")
+          jq -n --arg channel "C0AQLB1JXBL" --arg text "$MESSAGE" \
+            '{channel: $channel, text: $text}' \
+            | curl -sf -X POST https://slack.com/api/chat.postMessage \
+                -H "Authorization: Bearer ${{ secrets.SLACK_BOT_TOKEN }}" \
+                -H "Content-Type: application/json" \
+                --data-binary @- || true


### PR DESCRIPTION
## Summary
- Replaces hand-escaped Slack JSON strings in staging/production deploy workflows with `jq -n` payload construction.
- Uses `--data-binary @-` so multiline deploy messages are valid JSON and Slack notifications don’t break on newlines/backticks/actors.
- Covers deploy starting, deploy complete, deploy failed, and staging deploy notifications.

## Release evidence
- YAML parsed locally with Ruby `YAML.load_file` for `.github/workflows/deploy.yml` and `.github/workflows/deploy-staging.yml`.
- `git diff --check` passed.
- No user-facing site code changed; mobile QA N/A.

## Rollback
- Revert this PR to restore the previous inline Slack JSON payloads.

Linear: MJM-239
