### PR TITLE
fix(MJM-241): quote drift guard remote shell script

### DIFF
--- a/scripts/rolling-reno-drift-guard.mjs
+++ b/scripts/rolling-reno-drift-guard.mjs
@@ -60,7 +60,7 @@ function remoteManifest({ label, host, user, keyPath, themePath }) {
   }
   const remote = `${user}@${host}`;
   const script = `cd ${shellQuote(themePath)} && find . -type f ! -path './.git/*' ! -path './.github/*' ! -path './node_modules/*' ! -name '*.md' ! -name '.gitignore' -print0 | sort -z | xargs -0 sha256sum`;
-  const output = execFileSync('ssh', ['-i', keyPath, '-o', 'StrictHostKeyChecking=no', remote, 'bash', '-lc', script], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+  const output = execFileSync('ssh', ['-i', keyPath, '-o', 'StrictHostKeyChecking=no', remote, 'bash', '-lc', shellQuote(script)], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
   const manifest = new Map();
   for (const line of output.trim().split('\n').filter(Boolean)) {
     const match = line.match(/^([a-f0-9]{64})\s+\.\/(.+)$/);


### PR DESCRIPTION
## Summary
- Fixes MJM-241 drift guard remote manifest SSH quoting.
- Ensures `bash -lc` receives the full manifest script as one shell argument so `cd /www/wp-content/themes/rolling-reno-v2 && find ...` runs inside the deployed theme directory.

## Acceptance criteria / expected outcome
- Drift guard remote manifest reads the deployed theme directory, not the Flywheel SSH home directory.
- Remote manifest includes deployed theme files like `style.css` and `functions.php`.
- Remote manifest does not report SSH-home extras like `.bash_logout`, `.bash_profile`, or `.wp-cli`.

## Changed pages/components/scripts
- `scripts/rolling-reno-drift-guard.mjs` only.
- No pages, templates, CSS, or user-facing components changed.

## Staging or preview URL/evidence
- Direct staging SSH manifest with fixed quoting ✅
  - `style.css`: present
  - `functions.php`: present
  - `.bash_logout`: absent
  - `.bash_profile`: absent
  - `.wp-cli`: absent
- Full staging drift guard dry run with fixed quoting ✅ for the target failure mode:
  - `staging: 47 local files checked; missing=1, changed=1, extra=0`
  - Remaining `missing .git` is from the local git worktree metadata file, not a deployed theme file.
  - Remaining script hash drift is expected because this PR's script is not deployed yet.
  - URL probes returned HTTP 200 for `/`, `/blog/`, `/gear/`, `/start-here/`, `/full-time-rv-insurance/`.

## Validation
- `node --check scripts/rolling-reno-drift-guard.mjs` ✅

## QA notes
- User-facing UI/content: N/A — script-only deploy guard fix.
- Mobile QA: N/A — no front-end rendered change.
- Aoife UI/UX verdict: N/A — no visual/UI change.
- Sienna functional verdict: N/A — no user-facing functional flow change.
- Sarah copy QA verdict: N/A — no copy/content change.

## Branch freshness/rebase note
- Branch created from current `origin/main` at `566160a` (`feat(MJM-241): add Rolling Reno deploy drift guard (#71)`).

## Rollback note
- Revert this one-line script change.

## Post-merge required
1. Rerun staging deploy first.
2. Only after staging passes, rerun production deploy.

Do not touch MJM-240.
