### PR TITLE
fix(MJM-240): ignore worktree .git in drift guard

### DIFF
--- a/scripts/rolling-reno-drift-guard.mjs
+++ b/scripts/rolling-reno-drift-guard.mjs
@@ -26,7 +26,7 @@ function sha256(value) {
 }
 
 function shouldExclude(relPath) {
-  if (relPath === '.gitignore') return true;
+  if (relPath === '.git' || relPath === '.gitignore') return true;
   if (relPath.startsWith('.git/') || relPath.startsWith('.github/') || relPath.startsWith('node_modules/')) return true;
   if (relPath.endsWith('.md')) return true;
   return false;


### PR DESCRIPTION
## Summary
- Excludes the `.git` file from the Rolling Reno drift guard local manifest when the guard is run from a Git worktree checkout.
- Prevents a false `deployed theme is missing .git` failure while keeping `.git/`, `.github/`, `node_modules/`, Markdown, and `.gitignore` excluded.

## MJM-240 evidence
- Ran guard from isolated origin/main worktree before fix: prod/staging URL probes passed and theme parity only failed on `.git` missing.
- Ran REST read-only content comparison; no DB/content writes performed.
- Current content drift requiring explicit safe path/manual approval:
  - Pages: prod 22 / staging 22, changed 0.
  - Posts: prod 38 / staging 37; staging missing `rv-renovation-weekend-maintenance-checklist`.
  - Changed post: `best-vans-rvs-to-renovate-buyers-guide` content hash/length differs; prod modified `2026-04-28T01:56:17Z`, staging modified `2026-04-21T22:10:06Z`.
  - Category count deltas: `rv-life` 4 vs 3, `start-here-planning` 10 vs 9, explained by post drift.

## QA / release gate
- Test: `node --check scripts/rolling-reno-drift-guard.mjs` ✅
- Staging URL: N/A — deploy-script-only guard fix, no user-facing theme rendering change.
- Aoife visual QA: N/A — no UI/CSS/template change.
- Sienna functional QA: N/A — script syntax check passed; runtime deploy parity will validate when merged/deployed.
- Sarah copy QA: N/A — no copy/content changed.
- Branch freshness: branched from `origin/main` at `381b976` (`fix(MJM-241): quote drift guard remote shell script`).
- Rollback: revert this one-line script change.

## Safety
No production DB/content promotion, staging DB overwrite, wp-content sync, or REST write was run.
