### PR TITLE
fix(MJM-240): ignore worktree .git in drift guard

### DIFF
--- a/scripts/rolling-reno-drift-guard.mjs
+++ b/scripts/rolling-reno-drift-guard.mjs
@@ -26,7 +26,7 @@ function sha256(value) {
 }
 
 function shouldExclude(relPath) {
-  if (relPath === '.gitignore') return true;
+  if (relPath === '.git' || relPath === '.gitignore') return true;
   if (relPath.startsWith('.git/') || relPath.startsWith('.github/') || relPath.startsWith('node_modules/')) return true;
   if (relPath.endsWith('.md')) return true;
   return false;


### PR DESCRIPTION
## Summary
- excludes Git worktree `.git` file pointers from the Rolling Reno drift guard manifest
- keeps drift guard read-only; no DB/content writes

## Evidence
- node --check scripts/rolling-reno-drift-guard.mjs
- python3 /Users/cian/.openclaw/workspace/scripts/release-qa-gate-check.py --repo MJM-Agents/rolling-reno-theme --pr <this PR> --strict

## Release gates
- Acceptance criteria / expected outcome: prevent false drift failures caused by local Git worktree pointer files.
- Staging or preview URL/evidence: N/A script-only guard fix; deploy workflow will validate after merge.
- Changed pages/components/scripts: scripts/rolling-reno-drift-guard.mjs only.
- Mobile QA evidence: N/A no user-facing UI.
- Aoife UI/UX verdict: N/A script-only.
- Sienna functional verdict: required reviewer validation via drift guard/script checks; no UI regression expected.
- Sarah copy QA verdict: N/A no copy/content changed.
- Branch freshness/rebase note: branch created from origin/main on 2026-04-29; commit author/committer maps to `mjm-dex` via GitHub API.
- Rollback note: revert this commit if guard manifest behavior regresses.

MJM-240