### PR TITLE
chore: add PR issue-link template for Projects automation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+## Summary
+
+-
+
+## Canonical issue
+
+Fixes #
+
+<!-- Required: replace # with the canonical GitHub issue in this repo. Use "Refs owner/repo#123" for cross-repo work that should not close this issue. This powers GitHub Projects → Linked pull requests. -->
+
+## Validation
+
+-
+
+## Release / QA evidence
+
+- Staging URL or N/A:
+- Functional QA:
+- Visual QA:
+- Security/copy review if applicable:
+
+## Rollback
+
+-


### PR DESCRIPTION
Adds a PR template requiring a canonical `Fixes #...` / `Refs ...` issue link so GitHub Projects can populate Linked pull requests going forward.\n\nRefs MJM-Agents/openclaw-workspace#50