### PR TITLE
feat: add blog trust freshness strip

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2133,6 +2133,33 @@
 }
 .blog-discovery__header h2 { margin: 0 0 var(--space-3); }
 .blog-discovery__header p { max-width: 760px; margin: 0 0 var(--space-6); color: var(--color-text-muted); }
+.blog-trust-strip {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: var(--space-3);
+  margin: 0 0 var(--space-6);
+}
+.blog-trust-strip__item {
+  padding: var(--space-4);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-bg-warm);
+}
+.blog-trust-strip__label {
+  display: block;
+  margin-bottom: var(--space-1);
+  color: var(--color-forest);
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.blog-trust-strip__text {
+  display: block;
+  color: var(--color-text-secondary);
+  font-size: 14px;
+  line-height: 1.5;
+}
 .blog-search { max-width: 720px; margin-bottom: var(--space-6); }
 .blog-search__label { display: block; font-weight: 700; margin-bottom: var(--space-2); }
 .blog-search__row { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: var(--space-3); align-items: stretch; }
@@ -2145,6 +2172,7 @@
 .blog-index .cta-banner__inner { max-width: 100%; padding: 0; }
 @media (max-width: 760px) {
   .blog-discovery { padding: var(--space-5); }
+  .blog-trust-strip { grid-template-columns: 1fr; }
   .blog-search__row { grid-template-columns: 1fr; }
   .category-filter { width: 100%; border-radius: var(--radius-md); }
 }

--- a/home.php
+++ b/home.php
@@ -27,6 +27,21 @@ get_header();
                 <p><?php esc_html_e( 'Search by topic or choose a path. Your filters are shareable, so you can save or send the exact guide list.', 'rolling-reno' ); ?></p>
             </div>
 
+            <div class="blog-trust-strip" aria-label="<?php esc_attr_e( 'Rolling Reno editorial trust notes', 'rolling-reno' ); ?>">
+                <div class="blog-trust-strip__item">
+                    <span class="blog-trust-strip__label"><?php esc_html_e( 'Freshness', 'rolling-reno' ); ?></span>
+                    <span class="blog-trust-strip__text"><?php esc_html_e( 'Guides are reviewed as builds, gear, and road rules change.', 'rolling-reno' ); ?></span>
+                </div>
+                <div class="blog-trust-strip__item">
+                    <span class="blog-trust-strip__label"><?php esc_html_e( 'Hands-on', 'rolling-reno' ); ?></span>
+                    <span class="blog-trust-strip__text"><?php esc_html_e( 'Advice is grounded in Mara’s practical van and RV renovation experience.', 'rolling-reno' ); ?></span>
+                </div>
+                <div class="blog-trust-strip__item">
+                    <span class="blog-trust-strip__label"><?php esc_html_e( 'Transparent', 'rolling-reno' ); ?></span>
+                    <span class="blog-trust-strip__text"><?php esc_html_e( 'Affiliate links are disclosed and never change the price you pay.', 'rolling-reno' ); ?></span>
+                </div>
+            </div>
+
             <form class="blog-search" role="search" method="get" action="<?php echo esc_url( rr_blog_index_url() ); ?>">
                 <label class="blog-search__label" for="blog-search-input"><?php esc_html_e( 'Search Rolling Reno articles', 'rolling-reno' ); ?></label>
                 <div class="blog-search__row">


### PR DESCRIPTION
Refs #84

## Summary
- Adds a compact blog discovery trust/freshness strip on `/blog/` above search and category filters.
- Adds responsive styling for the new trust-strip cards.

## Acceptance criteria / expected outcome
- Blog visitors see immediate freshness, hands-on, and affiliate-transparency trust signals before browsing or searching.
- The change stays limited to the blog discovery strip and does not alter post query/filter behavior.

## Changed pages/components/scripts evidence
- Changed pages: `/blog/` posts index via `home.php`
- Changed components: blog discovery trust/freshness strip
- Changed styles: `assets/css/main.css`
- Changed scripts: none
- Diff scope: 2 files, 43 insertions

## Branch freshness / rebase note
- Branch `saoirse/issue-84-freshness-trust-strip` was created from Lorcan’s reviewed commit `c9c1029` after `lorcan/issue-84-freshness-trust-improvement` had a hidden/stale PR association.
- Branch freshness verified against `origin/main` before PR creation.
- Evidence: `git rev-list --left-right --count origin/main...HEAD` => `0 1`; `origin/main` is an ancestor of HEAD.

## Validation evidence
- `git diff origin/main...HEAD --check` passed
- `npm_config_cache=/tmp/.npm npm ci` passed; 0 vulnerabilities
- `PROD_URL=https://rollingreno.com npm_config_cache=/tmp/.npm npm run drift:guard` passed
- GitHub `rolling-reno-regression` check passed on PR #86
- Production probes returned HTTP 200 for `/`, `/blog/`, `/gear/`, `/start-here/`, `/full-time-rv-insurance/`

## Staging / preview evidence
- Host validation completed for this template/CSS-only change.
- No separate staging/preview URL was available in the review environment.
- Production drift guard was run against `https://rollingreno.com`; after deploy, visually check `/blog/` for the new trust strip.

## QA verdict status
- Aoife UI/UX verdict: N/A specialist verdict unavailable; host reviewer inspected the isolated responsive CSS/template change for layout risk.
- Sienna functional verdict: N/A specialist verdict unavailable; no functional/query/script behavior changed, and drift guard + regression check passed.
- Sarah copy QA verdict: Cian host copy QA pass for short trust-strip copy in `home.php`; copy is concise, transparent, and limited to freshness/hands-on/affiliate disclosure notes.

## Rollback note
- Roll back by reverting PR #86 / its squash commit. The change is isolated to `home.php` and `assets/css/main.css`; no database, script, or content migration is involved.

## Environment notes
- PHP CLI unavailable in review environment.
- Playwright browser install unavailable in original sandbox.
