### PR TITLE
fix: clarify Rolling Reno drift guard access blockers

### DIFF
--- a/scripts/rolling-reno-drift-guard.config.json
+++ b/scripts/rolling-reno-drift-guard.config.json
@@ -1,5 +1,5 @@
 {
-  "paths": ["/", "/blog/", "/gear/", "/start-here/", "/full-time-rv-insurance/"],
+  "paths": ["/", "/blog/", "/gear/", "/start-here/", "/full-time-rv-insurance/", "/best-vans-rvs-to-renovate-buyers-guide/"],
   "expectedMarkers": {
     "all": [
       "Rolling Reno",
@@ -10,7 +10,8 @@
     "/blog/": ["blog-discovery", "category-filter"],
     "/gear/": ["amazon.com", "tag=rollingreno-20"],
     "/start-here/": ["Start Here"],
-    "/full-time-rv-insurance/": ["insurance"]
+    "/full-time-rv-insurance/": ["insurance"],
+    "/best-vans-rvs-to-renovate-buyers-guide/": ["Buyer", "renovate"]
   },
   "urlSizeDeltaWarnRatio": 0.25,
   "remoteThemePath": "/www/wp-content/themes/rolling-reno-v2",

--- a/scripts/rolling-reno-drift-guard.mjs
+++ b/scripts/rolling-reno-drift-guard.mjs
@@ -162,6 +162,10 @@ function compareUrlProbes(left, right) {
   for (const probe of right) {
     const base = byKey.get(probe.path);
     if (!base) continue;
+    if (base.status !== 200 || probe.status !== 200) {
+      warnings.push(`${base.target} vs ${probe.target} ${probe.path}: content drift comparison skipped because probe status was ${base.target}=${base.status}, ${probe.target}=${probe.status}. Resolve access/HTTP failures before treating response hashes or sizes as content drift.`);
+      continue;
+    }
     const maxSize = Math.max(base.size, probe.size, 1);
     const deltaRatio = Math.abs(base.size - probe.size) / maxSize;
     if (base.hash !== probe.hash) {


### PR DESCRIPTION
## Summary

- Skip prod↔staging content-drift hash/size comparisons when either URL probe is not HTTP 200, so privacy/auth failures are reported as access blockers instead of noisy false content drift.
- Add the buyer’s-guide slug from the known #64 drift inventory to the drift guard probe list.

## Canonical issue

Refs #64

## Acceptance criteria / expected outcome

- When staging privacy/auth returns HTTP 401, the drift guard must report that as an access/HTTP blocker and skip prod↔staging content hash/size comparison for that URL.
- The guard must not classify the Flywheel privacy-auth 401 HTML page as production/staging content drift.
- Production buyer-guide probe `/best-vans-rvs-to-renovate-buyers-guide/` must be included in the monitored URL list and pass HTTP 200 with expected markers.
- No CMS, DB, staging, or production content mutation is attempted by this PR.

## Branch freshness evidence

- 2026-05-24 05:54 EDT: ran `git fetch origin --prune`.
- Current branch `sarah/issue-64-content-drift` contains `origin/main`:
  - `git merge-base HEAD origin/main == git rev-parse origin/main` ✅
  - `git rev-list --left-right --count HEAD...origin/main` returned `1 0` ✅ — branch is one commit ahead, zero commits behind `origin/main`.

## Validation

- `node --check scripts/rolling-reno-drift-guard.mjs` ✅
- `PROD_URL=https://rollingreno.com DRIFT_GUARD_TARGETS=prod npm run drift:guard` ✅
  - Production `/best-vans-rvs-to-renovate-buyers-guide/`: HTTP 200, expected markers present.
  - Production `/`, `/blog/`, `/gear/`, `/start-here/`, `/full-time-rv-insurance/`: HTTP 200.
- `PROD_URL=https://rollingreno.com STAGING_URL=https://rollingreno.flywheelstaging.com DRIFT_GUARD_TARGETS=prod,staging npm run drift:guard` ❌ expected blocker:
  - Staging returns HTTP 401 on all checked URLs without privacy credentials.
  - New behavior reports: `content drift comparison skipped because probe status was prod=200, staging=401. Resolve access/HTTP failures before treating response hashes or sizes as content drift.`
- GitHub check `rolling-reno-regression` ✅ passed in 48s: https://github.com/MJM-Agents/rolling-reno-theme/actions/runs/26358003861/job/77588187835

## Release / QA evidence

- Staging URL: N/A/blocked — live staging URL exists (`https://rollingreno.flywheelstaging.com`) but returns HTTP 401 from this session without `STAGING_AUTH_USER` / `STAGING_AUTH_PASS`; visual/live staging QA cannot be completed until credentials are available.
- Functional QA: ✅ covered by local syntax check, production probe run, blocked staging probe run, and GitHub regression check above.
- Visual QA: N/A — this PR changes Node drift-guard logic/config only; no PHP templates, CSS, JS frontend behavior, or rendered UI output changed. Live staging visual QA is also blocked by HTTP 401 privacy auth.
- Sarah/copy QA: ✅ Sarah-owned copy/tooling review complete; user-facing site copy is unchanged. PR text clarifies operational language only.
- Cian/release QA: N/A for deploy/live release gate — this is a guardrail/tooling-only PR and does not deploy content or mutate CMS/DB state. Merge still requires normal reviewer approval.
- Security QA: N/A — no auth/security logic changed, no secrets added, no external write path introduced.

## Changed files

- `scripts/rolling-reno-drift-guard.config.json` — changed scripts/config only; adds `/best-vans-rvs-to-renovate-buyers-guide/` to monitored drift-guard probes and expected marker checks.
- `scripts/rolling-reno-drift-guard.mjs` — changed script logic only; skips prod↔staging content hash/size comparison when either probe returns non-200 and reports the access/HTTP failure as the blocker.

## Required copy / host QA verdicts

- Sarah copy QA verdict: N/A — no user-facing site copy, blog content, PHP templates, CSS, or rendered UI changed; only internal drift-guard operational wording/config changed.
- Cian host copy QA verdict: N/A — tooling-only guardrail change; no CMS/DB/content mutation and no production/staging content copy changed.

## Merge readiness / blocked status

- `mergeable=MERGEABLE` ✅
- Checks are green ✅
- `mergeStateStatus=BLOCKED` is currently explained by `reviewDecision=CHANGES_REQUESTED` from Lorcan’s review/routing comment, not by failing CI or branch staleness.
- Re-review requested after this evidence update.

## Rollback

- Revert this PR to restore the previous drift guard comparison behavior and probe list.

