### PR TITLE
chore: add content drift inventory for RR64

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test:regression": "playwright test tests/e2e/regression.spec.ts",
     "test:install": "playwright install chromium",
     "drift:guard": "node scripts/rolling-reno-drift-guard.mjs",
+    "drift:inventory": "node scripts/rolling-reno-content-drift-inventory.mjs",
     "publisher:qa": "node scripts/rolling-reno-publisher-qa.mjs",
     "rr103:apply-live": "node scripts/rr103-apply-live-fix.mjs"
   },

--- a/scripts/rolling-reno-content-drift-inventory.mjs
+++ b/scripts/rolling-reno-content-drift-inventory.mjs
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+
+const DEFAULT_TYPES = ['posts', 'pages', 'categories'];
+const DEFAULT_PROD_URL = 'https://rollingreno.com';
+const DEFAULT_STAGING_URL = 'https://rollingreno.flywheelstaging.com';
+const targets = [
+  targetFromEnv('prod', DEFAULT_PROD_URL),
+  targetFromEnv('staging', DEFAULT_STAGING_URL),
+].filter(Boolean);
+const failures = [];
+
+function targetFromEnv(label, fallbackUrl) {
+  const upper = label.toUpperCase();
+  const url = (process.env[`${upper}_URL`] || fallbackUrl || '').replace(/\/$/, '');
+  if (!url) return null;
+  return {
+    label,
+    url,
+    authUser: process.env[`${upper}_AUTH_USER`] || '',
+    authPass: process.env[`${upper}_AUTH_PASS`] || '',
+  };
+}
+
+function authHeaders(target) {
+  const headers = { 'User-Agent': 'RollingRenoContentDriftInventory/1.0' };
+  if (target.authUser || target.authPass) {
+    headers.Authorization = `Basic ${Buffer.from(`${target.authUser}:${target.authPass}`).toString('base64')}`;
+  }
+  return headers;
+}
+
+function stripHtml(value = '') {
+  return String(value)
+    .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function wordCount(value = '') {
+  const text = stripHtml(value);
+  if (!text) return 0;
+  return text.split(/\s+/).length;
+}
+
+function endpoint(target, type, page) {
+  const url = new URL(`/wp-json/wp/v2/${type}`, `${target.url}/`);
+  url.searchParams.set('per_page', '100');
+  url.searchParams.set('page', String(page));
+  if (type !== 'categories') {
+    url.searchParams.set('status', 'publish');
+    url.searchParams.set('_fields', 'id,slug,link,modified_gmt,title,content,excerpt');
+  } else {
+    url.searchParams.set('_fields', 'id,slug,link,name,count');
+  }
+  return url;
+}
+
+async function fetchCollection(target, type) {
+  const items = [];
+  for (let page = 1; page <= 20; page += 1) {
+    const url = endpoint(target, type, page);
+    const res = await fetch(url, { headers: authHeaders(target), signal: AbortSignal.timeout(20000) });
+    if (!res.ok) {
+      const body = await res.text().catch(() => '');
+      throw new Error(`${target.label} ${type}: HTTP ${res.status} at ${url.href}${body ? ` (${body.slice(0, 120).replace(/\s+/g, ' ')})` : ''}`);
+    }
+    const batch = await res.json();
+    if (!Array.isArray(batch)) throw new Error(`${target.label} ${type}: expected array response`);
+    items.push(...batch);
+    const totalPages = Number(res.headers.get('x-wp-totalpages') || '1');
+    if (page >= totalPages || batch.length === 0) break;
+  }
+  return items;
+}
+
+async function collect(target) {
+  const data = {};
+  for (const type of DEFAULT_TYPES) data[type] = await fetchCollection(target, type);
+  return data;
+}
+
+function bySlug(items) {
+  return new Map(items.map((item) => [item.slug, item]));
+}
+
+function compareSlugSet(type, leftLabel, leftItems, rightLabel, rightItems) {
+  const left = bySlug(leftItems);
+  const right = bySlug(rightItems);
+  const leftOnly = [...left.keys()].filter((slug) => !right.has(slug)).sort();
+  const rightOnly = [...right.keys()].filter((slug) => !left.has(slug)).sort();
+  console.log(`\n### ${type}`);
+  console.log(`${leftLabel}: ${leftItems.length}; ${rightLabel}: ${rightItems.length}`);
+  if (leftOnly.length) console.log(`${leftLabel}-only: ${leftOnly.join(', ')}`);
+  if (rightOnly.length) console.log(`${rightLabel}-only: ${rightOnly.join(', ')}`);
+  if (!leftOnly.length && !rightOnly.length) console.log('Slug sets match.');
+  return { left, right, leftOnly, rightOnly };
+}
+
+function compareSharedContent(type, leftLabel, left, rightLabel, right) {
+  if (type === 'categories') return;
+  const shared = [...left.keys()].filter((slug) => right.has(slug)).sort();
+  const material = [];
+  for (const slug of shared) {
+    const a = left.get(slug);
+    const b = right.get(slug);
+    const aWords = wordCount(a.content?.rendered || a.excerpt?.rendered || '');
+    const bWords = wordCount(b.content?.rendered || b.excerpt?.rendered || '');
+    const max = Math.max(aWords, bWords, 1);
+    const delta = Math.abs(aWords - bWords) / max;
+    const titleA = stripHtml(a.title?.rendered || '');
+    const titleB = stripHtml(b.title?.rendered || '');
+    if (delta >= 0.1 || titleA !== titleB) {
+      material.push({ slug, titleA, titleB, aWords, bWords, delta });
+    }
+  }
+  if (!material.length) {
+    console.log(`Shared ${type}: no material title/body word-count drift at 10% threshold.`);
+    return;
+  }
+  console.log(`Shared ${type}: material title/body drift:`);
+  for (const item of material) {
+    console.log(`- ${item.slug}: ${leftLabel} ${item.aWords} words / ${JSON.stringify(item.titleA)}; ${rightLabel} ${item.bWords} words / ${JSON.stringify(item.titleB)} (${Math.round(item.delta * 100)}% delta)`);
+  }
+}
+
+console.log('# Rolling Reno content drift inventory');
+console.log('Read-only WP REST comparison. No CMS writes or DB sync attempted.');
+console.log(`Targets: ${targets.map((target) => `${target.label}=${target.url}`).join(', ')}`);
+
+if (targets.length < 2) failures.push('Need both PROD_URL and STAGING_URL targets for drift inventory.');
+
+const results = new Map();
+for (const target of targets) {
+  try {
+    console.log(`\n## Fetching ${target.label}`);
+    const data = await collect(target);
+    results.set(target.label, data);
+    console.log(`Fetched posts=${data.posts.length}, pages=${data.pages.length}, categories=${data.categories.length}`);
+  } catch (error) {
+    failures.push(error.message);
+  }
+}
+
+if (results.has('prod') && results.has('staging')) {
+  console.log('\n## Drift comparison');
+  const prod = results.get('prod');
+  const staging = results.get('staging');
+  for (const type of DEFAULT_TYPES) {
+    const { left, right } = compareSlugSet(type, 'prod', prod[type], 'staging', staging[type]);
+    compareSharedContent(type, 'prod', left, 'staging', right);
+  }
+}
+
+if (failures.length) {
+  console.log('\n## Blockers');
+  for (const failure of failures) console.log(`❌ ${failure}`);
+  process.exitCode = 1;
+} else {
+  console.log('\n## Result');
+  console.log('✅ Content drift inventory completed. Use the slug/title/body deltas for targeted manual production → staging sync; do not full-overwrite either DB.');
+}


### PR DESCRIPTION
## Summary

- Adds a read-only WP REST content drift inventory script for the remaining staging-vs-production reconciliation lane.
- Exposes it as `npm run drift:inventory`.
- Keeps the sync path explicit and safe: inventory only, no CMS writes, no DB overwrite.

## Canonical issue

Refs #64

## Acceptance criteria / expected outcome

- Operators can run `npm run drift:inventory` to produce a repeatable production-vs-staging WordPress REST inventory for posts, pages, and categories.
- The script is read-only: no CMS writes, no database overwrite, and no file mutation.
- When staging is protected by Flywheel privacy auth, the script fails safely with an explicit HTTP 401 blocker after successfully proving production inventory access.
- The broader #64 content reconciliation remains blocked until staging credentials and explicit CMS-write approval are available.

## Changed pages/components/scripts

- Changed scripts: `scripts/rolling-reno-content-drift-inventory.mjs`
- Changed package scripts: `package.json` adds `drift:inventory`
- Changed pages: none
- Changed components/templates/styles: none
- User-facing site content/UI: none

## Validation

- `node --check scripts/rolling-reno-content-drift-inventory.mjs` ✅
- `npm run drift:inventory` ⚠️ expected external blocker reproduced: production REST inventory fetched successfully (`posts=61, pages=22, categories=11`), then staging REST returned HTTP 401 from Flywheel privacy auth before content comparison.
- `PROD_URL=https://rollingreno.com DRIFT_GUARD_TARGETS=prod npm run drift:guard` ✅ production probes HTTP 200 for `/`, `/blog/`, `/gear/`, `/start-here/`, `/full-time-rv-insurance/`, and `/best-vans-rvs-to-renovate-buyers-guide/`.
- GitHub check `rolling-reno-regression` ✅ passed: https://github.com/MJM-Agents/rolling-reno-theme/actions/runs/26423207214/job/77781773766

## Release / QA evidence

- Staging URL or N/A: N/A for this PR’s code slice. Staging content inventory is intentionally blocked by Flywheel privacy HTTP 401 until `STAGING_AUTH_USER` / `STAGING_AUTH_PASS` or equivalent WP/SSH credentials are available. No staging deploy/content mutation was attempted.
- UI/UX verdict: N/A — no theme template, CSS, or rendered UI changes. The PR adds a read-only CLI inventory script and package script only.
- Functional verdict / host validation: PASS — `node --check` passed; `npm run drift:inventory` successfully inventories production via WP REST and fails safely with the explicit staging HTTP 401 blocker; prod-only `npm run drift:guard` passed all configured URL/marker probes.
- Sarah copy QA verdict: N/A — no customer-facing copy/content changed.
- Cian host copy QA verdict: N/A — no customer-facing copy/content changed; PR evidence text reviewed for clarity.
- Security/copy review if applicable: Security impact is low/read-only. The script only performs authenticated HTTP GETs when credentials are supplied via environment variables; it does not log credential values, write to WordPress, or mutate files/CMS state.

## Branch freshness / rebase note

- Branch `sarah/issue-64-content-sync-runbook` is based on current `main` at `b7a4411a14cd16101072f116a9d5130bfb402278`.
- Freshness checked from local review clone: `origin/main...origin/pr/111 = 0 1`, and `origin/main` is an ancestor of the PR head.
- PR head: `cfc41e039ab9507876c3c028fbf358b42927b976`.

## Rollback note

- Revert this PR to remove `scripts/rolling-reno-content-drift-inventory.mjs` and the `drift:inventory` package script. No CMS/database rollback is needed because this PR performs no external writes.

## Current blocker / next owner

The broader #64 content/admin reconciliation remains blocked on staging credentials and explicit CMS-write approval. Next owner with access should run `STAGING_AUTH_USER=... STAGING_AUTH_PASS=... npm run drift:inventory`, then perform only targeted production → staging sync after backup/approval. Do not full-overwrite either DB.