### PR TITLE
Fix #118: Refresh enhanced pagination hide path

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -414,7 +414,9 @@
 
     if (fallbackPagination) {
       fallbackPagination.setAttribute('aria-hidden', 'true');
-      fallbackPagination.style.display = 'none';
+      fallbackPagination.style.setProperty('display', 'none', 'important');
+      fallbackPagination.style.setProperty('visibility', 'hidden', 'important');
+      fallbackPagination.style.setProperty('pointer-events', 'none', 'important');
     }
 
     function setStatus(state) {

--- a/functions.php
+++ b/functions.php
@@ -6,7 +6,7 @@
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define( 'RR_VERSION', '2.0.12' );
+define( 'RR_VERSION', '2.0.13' );
 define( 'RR_THEME_DIR', get_template_directory() );
 define( 'RR_THEME_URI', get_template_directory_uri() );
 
@@ -140,6 +140,13 @@ function rr_scripts() {
         array( 'rr-main' ),
         RR_VERSION
     );
+
+    if ( is_home() || rr_is_blog_index_request() ) {
+        wp_add_inline_style(
+            'rr-theme',
+            'html.rr-infinite-scroll-ready body .blog-index nav.navigation.pagination[aria-hidden="true"]{display:none!important;visibility:hidden!important;pointer-events:none!important;}'
+        );
+    }
 
     wp_enqueue_script(
         'rolling-reno-main',

--- a/tests/e2e/regression.spec.ts
+++ b/tests/e2e/regression.spec.ts
@@ -113,10 +113,19 @@ test.describe('Rolling Reno regression guardrails', () => {
   test('enhanced blog archive hides fallback pagination links', async ({ page }) => {
     await page.setContent(`
       <style>
-        .navigation.pagination { display: block; }
-        .page-numbers { display: inline-flex; }
         .rr-infinite-scroll-ready .blog-index .navigation.pagination {
+          display: none;
+        }
+        .navigation.pagination,
+        .blog-index .navigation.pagination[aria-hidden="true"] {
+          display: block !important;
+          visibility: visible !important;
+        }
+        .page-numbers { display: inline-flex; }
+        html.rr-infinite-scroll-ready body .blog-index nav.navigation.pagination[aria-hidden="true"] {
           display: none !important;
+          visibility: hidden !important;
+          pointer-events: none !important;
         }
       </style>
       <main class="blog-index">
@@ -138,6 +147,9 @@ test.describe('Rolling Reno regression guardrails', () => {
       document.documentElement.classList.add('rr-infinite-scroll-ready');
       const pagination = document.querySelector('.blog-index .navigation.pagination');
       pagination?.setAttribute('aria-hidden', 'true');
+      pagination?.style.setProperty('display', 'none', 'important');
+      pagination?.style.setProperty('visibility', 'hidden', 'important');
+      pagination?.style.setProperty('pointer-events', 'none', 'important');
     });
 
     await expect(fallbackPagination).toBeHidden();

--- a/tests/static/comments-disabled.test.mjs
+++ b/tests/static/comments-disabled.test.mjs
@@ -93,8 +93,21 @@ assert(
 );
 
 assert(
-  mainScript.includes("fallbackPagination.style.display = 'none'"),
-  'blog infinite-scroll JS must inline-hide fallback pagination after enhancement initializes.',
+  functionsTemplate.includes("define( 'RR_VERSION', '2.0.13' )"),
+  'theme asset version must be bumped when changing cached public CSS/JS.',
+);
+
+assert(
+  functionsTemplate.includes('wp_add_inline_style') &&
+    functionsTemplate.includes('html.rr-infinite-scroll-ready body .blog-index nav.navigation.pagination[aria-hidden="true"]') &&
+    functionsTemplate.includes('display:none!important'),
+  'blog archive must enqueue a critical enhanced-state pagination hide rule with the theme stylesheet.',
+);
+
+assert(
+  mainScript.includes("fallbackPagination.style.setProperty('display', 'none', 'important')") &&
+    mainScript.includes("fallbackPagination.style.setProperty('visibility', 'hidden', 'important')"),
+  'blog infinite-scroll JS must important-inline-hide fallback pagination after enhancement initializes.',
 );
 
 assert(


### PR DESCRIPTION
Fixes #118 follow-up after PR #120 merged/deployed but production still showed fallback pagination.

## Acceptance / Expected outcome
Enhanced blog archive users must not see `Older posts` or numbered fallback pagination after infinite scroll initializes. No-JS and crawler users must retain server-rendered paginated archive links.

## Changed pages/components/scripts
- `/blog/` archive enhanced state
- `functions.php` asset version and critical inline enhanced-state CSS
- `assets/js/main.js` infinite-scroll fallback pagination inline hide
- `tests/e2e/regression.spec.ts` and `tests/static/comments-disabled.test.mjs` regression coverage

## Production evidence / root cause
- Production HTML still loaded `rr-theme-css` and `rolling-reno-main-js` with `?ver=2.0.12`.
- `style.css?ver=2.0.12` returned `cache-control: public, max-age=31536000` and still contained the old non-important hide rule.
- Live browser reproduction had `html.rr-infinite-scroll-ready=true` and `aria-hidden="true"` on `.navigation.pagination`, but computed display remained `block` and links `2`, `3`, `9`, and `Older posts →` were visible.

## Validation
- `npm test`
- `node --check assets/js/main.js`
- `npm run test:regression -- -g "enhanced blog archive hides fallback pagination links"` (desktop + mobile)
- `git diff --check origin/main...HEAD`
- Flywheel PHP 8.2.31 lint via stdin for modified `functions.php`
- Flywheel PHP 8.2.31 lint on production `functions.php`, `home.php`, `template-parts/content-card.php`

## QA verdicts
- Functional verdict: PASS locally. Rendered desktop/mobile regression models stale/competing pagination CSS and verifies enhanced pagination links are hidden.
- UI/UX verdict: PASS for scoped hotfix. No new visible UI; only enhanced fallback pagination visibility changes.
- Sarah copy QA verdict: N/A, no copy changes.
- Cian host copy QA verdict: N/A, no copy changes.

## Branch freshness / rebase note
Branch created from current `origin/main` at PR #120 merge commit `f21b5860daa05b3a479dced0469c33e321d7b40a`.

## Staging or preview URL/evidence
No branch staging URL is available at PR creation. Evidence is production mismatch inspection plus local rendered Playwright desktop/mobile and Flywheel PHP host lint. Production live verification must run after merge/deploy on `https://rollingreno.com/blog/`.

## Rollback note
Revert this PR to restore PR #120 behavior. Raw `the_posts_pagination()` fallback remains server-rendered for no-JS/crawlers.

## Release QA
#118 must remain open until this hotfix is merged, deployed, and production desktop/mobile live verification passes.